### PR TITLE
fix: idempotent subflow spawn via deterministic child runId

### DIFF
--- a/packages/core/src/run-id.ts
+++ b/packages/core/src/run-id.ts
@@ -25,3 +25,33 @@ export const RunId = {
     return s as RunId;
   },
 } as const;
+
+// Deterministic, name-based RunId for a subflow child, derived from its parent
+// (runId, stepId, attempt). Durable execution is at-least-once: a parent
+// subflow step can be re-delivered and re-execute its spawn. Minting a random
+// id each time would create a second child that cancel-in-progress then
+// self-supersedes, failing the parent. A deterministic id means a re-delivery
+// of the SAME attempt resolves to the SAME child (tryStartRun re-attaches), so
+// the spawn is idempotent — while a genuine retry (new attempt) still gets a
+// fresh child. RFC-4122 v5-shaped (SHA-256 truncated to 16 bytes; version and
+// variant bits set) so it is indistinguishable from a minted random id. Async
+// + Web-Crypto (crypto.subtle) to stay runtime-agnostic, matching canonicalize.
+export async function deriveChildRunId(parent: {
+  readonly runId: RunId;
+  readonly stepId: string;
+  readonly attempt: number;
+}): Promise<RunId> {
+  const seed = `nagi:subflow:${parent.runId}:${parent.stepId}:${parent.attempt}`;
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(seed),
+  );
+  const bytes = new Uint8Array(digest).subarray(0, 16);
+  bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x50; // version 5
+  bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80; // RFC 4122 variant
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join(
+    "",
+  );
+  const uuid = `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+  return `run-${uuid}` as RunId;
+}

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -18,6 +18,7 @@ import { DEFAULT_REAPER_INTERVAL_MS } from "./lease-reaper";
 import { InMemoryClock } from "./memory";
 import { makeOperator } from "./operator";
 import { makeReplay } from "./replay";
+import { deriveChildRunId } from "./run-id";
 import type { RunDescription } from "./run-view";
 import { nextTransition } from "./scheduler";
 import { makeSignals } from "./signals";
@@ -356,18 +357,21 @@ async function nagiImpl<const TFlows extends ReadonlyArray<Flow>>(
       );
     }
     const validated = (await validate(child.input, childInput)) as Json;
-    const childRunId = mintRunId();
-    const { started } = await startRunInternal({
+    // Deterministic per (parentRunId, stepId, attempt) so an at-least-once
+    // re-delivery of this subflow step re-attaches to the existing child
+    // instead of spawning a duplicate that cancel-in-progress would then
+    // self-supersede (failing the parent). See deriveChildRunId.
+    const childRunId = await deriveChildRunId(parent);
+    // started === false ⇒ this exact (parentRunId, stepId, attempt) already
+    // spawned the child on a prior delivery. tryStartRun checks run existence
+    // before its concurrency-cancel pass, so re-attaching cancels nothing and
+    // leaves the original child (and its parent link) intact. Idempotent.
+    await startRunInternal({
       flow: child,
       validatedInput: validated,
       runId: childRunId,
       parent,
     });
-    if (!started) {
-      throw new NagiRuntimeError(
-        `startChildRun: minted child runId collided with an existing run (${childRunId})`,
-      );
-    }
     return childRunId;
   }
 

--- a/packages/core/src/tests/run-id.test.ts
+++ b/packages/core/src/tests/run-id.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { NagiValidationError } from "../errors";
-import { RunId } from "../run-id";
+import { deriveChildRunId, RunId } from "../run-id";
 
 describe("RunId.parse", () => {
   it("accepts a non-empty string and returns a branded RunId", () => {
@@ -31,5 +31,35 @@ describe("RunId brand", () => {
     const parsed = JSON.parse(json) as { runId: string };
     const back = RunId.parse(parsed.runId);
     expect(back).toBe(id);
+  });
+});
+
+describe("deriveChildRunId", () => {
+  const base = {
+    runId: RunId.fromTrusted("run-parent-1"),
+    stepId: "sub",
+    attempt: 1,
+  };
+
+  it("is deterministic for the same (runId, stepId, attempt)", async () => {
+    expect(await deriveChildRunId(base)).toBe(await deriveChildRunId(base));
+  });
+
+  it("differs by attempt, stepId, and parent runId", async () => {
+    const id = await deriveChildRunId(base);
+    expect(await deriveChildRunId({ ...base, attempt: 2 })).not.toBe(id);
+    expect(await deriveChildRunId({ ...base, stepId: "other" })).not.toBe(id);
+    expect(
+      await deriveChildRunId({
+        ...base,
+        runId: RunId.fromTrusted("run-parent-2"),
+      }),
+    ).not.toBe(id);
+  });
+
+  it("produces a run- prefixed, RFC-4122 v5-shaped id", async () => {
+    expect(await deriveChildRunId(base)).toMatch(
+      /^run-[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
   });
 });

--- a/packages/core/src/tests/subflow.test.ts
+++ b/packages/core/src/tests/subflow.test.ts
@@ -373,3 +373,60 @@ describe("b.subflow — registration", () => {
     expect(err.message).toContain("not registered");
   });
 });
+
+describe("b.subflow — idempotent spawn (self-supersede regression)", () => {
+  // Reproduces the prod incident (2026-05-29): a parent re-delivered its
+  // subflow-spawning step (at-least-once), spawning the SAME child twice; the
+  // child's cancel-in-progress concurrency made the 2nd spawn cancel the 1st,
+  // and the parent step (bound to the 1st) failed with NagiCanceledError.
+  // With deterministic child run ids the 2nd spawn re-attaches instead.
+  it("re-delivering a subflow step yields ONE child, not a self-supersede", async () => {
+    const child = flow({
+      id: "child-cip",
+      input: passthroughSchema<{ x: number }>(),
+      // Same key for every spawn: if two children with different ids existed,
+      // the second start would cancel the first.
+      concurrency: { keyFn: () => "fixed", mode: "cancel-in-progress" },
+      build: (b) => ({
+        work: b.task({ run: async ({ input }) => ({ doubled: input.x * 2 }) }),
+      }),
+      output: (steps) => steps.work,
+    });
+    // Minimal parent — only needed to own a runId / parent link. We drive the
+    // duplicate spawn directly via startChildRun to model redelivery of the
+    // same (parentRunId, stepId, attempt) without lease/queue plumbing.
+    const parent = flow({
+      id: "parent-host",
+      input: passthroughSchema<Record<string, never>>(),
+      build: (b) => ({ noop: b.task({ run: async () => ({ ok: true }) }) }),
+    });
+
+    const h = await makeHarness([parent, child]);
+    const parentRunId = await h.wf.start(parent, {});
+    await h.drain();
+
+    const parentRef = { runId: parentRunId, stepId: "sub", attempt: 1 };
+    const first = await h.deps.startChildRun({
+      child,
+      childInput: { x: 5 },
+      parent: parentRef,
+    });
+    const second = await h.deps.startChildRun({
+      child,
+      childInput: { x: 5 },
+      parent: parentRef,
+    });
+
+    // Deterministic id ⇒ the redelivery re-attached to the same child.
+    expect(second).toBe(first);
+
+    // Exactly one child run exists for this parent.
+    const children = await h.store.listChildren(parentRunId);
+    expect(children).toEqual([first]);
+
+    // The child was never canceled by a self-supersede; it runs to completion.
+    await h.drain();
+    const childState = await h.store.loadRunState(first);
+    expect(childState.phase.tag).toBe("completed");
+  });
+});

--- a/packages/postgres/src/integration.test.ts
+++ b/packages/postgres/src/integration.test.ts
@@ -755,6 +755,69 @@ d("@nagi-js/postgres — end-to-end conformance", () => {
       expect(children.length).toBe(1);
     }, 20_000);
 
+    it("re-spawning a subflow step re-attaches via PG (idempotent, no self-supersede)", async () => {
+      // Child has cancel-in-progress on a fixed key: if a re-delivery minted a
+      // second child with a different id, the real SQL tryStartRun would cancel
+      // the first. Deterministic ids make the existence check fire first, so the
+      // second spawn re-attaches — proving the load-bearing PG ordering.
+      const child = flow({
+        id: "pg-idem-child",
+        input: passthroughSchema<{ x: number }>(),
+        concurrency: { keyFn: () => "fixed", mode: "cancel-in-progress" },
+        build: (b) => ({
+          work: b.task({
+            run: async ({ input }) => ({ doubled: input.x * 2 }),
+          }),
+        }),
+        output: (s) => s.work,
+      });
+      const parent = flow({
+        id: "pg-idem-parent",
+        input: passthroughSchema<Record<string, never>>(),
+        build: (b) => ({ noop: b.task({ run: async () => ({ ok: true }) }) }),
+      });
+
+      const wf = await makeNagi(parent, child);
+      const parentRunId = await wf.start(parent, {});
+      await runToEnd(wf, parentRunId);
+
+      const startChildRun = (
+        wf as unknown as {
+          __dispatchDeps: {
+            startChildRun: (a: {
+              readonly child: typeof child;
+              readonly childInput: unknown;
+              readonly parent: {
+                runId: RunId;
+                stepId: string;
+                attempt: number;
+              };
+            }) => Promise<RunId>;
+          };
+        }
+      ).__dispatchDeps.startChildRun;
+
+      const parentRef = { runId: parentRunId, stepId: "sub", attempt: 1 };
+      const first = await startChildRun({
+        child,
+        childInput: { x: 5 },
+        parent: parentRef,
+      });
+      const second = await startChildRun({
+        child,
+        childInput: { x: 5 },
+        parent: parentRef,
+      });
+      expect(second).toBe(first);
+
+      const rows = await sql<{ run_id: string; status: string }>`
+        SELECT run_id, status FROM ${sql.raw(`${schema}.workflow_run`)}
+         WHERE parent_run_id = ${parentRunId}
+      `.execute(db);
+      expect(rows.rows.length).toBe(1);
+      expect(rows.rows[0]?.status).not.toBe("canceled");
+    }, 20_000);
+
     it("wf.cancel transitively cancels children", async () => {
       const grandchild = flow({
         id: "pg-cancel-gc",


### PR DESCRIPTION
## Problem

A parent run that re-delivers its subflow-spawning step (durable execution is **at-least-once**) minted a fresh **random** child `runId` on each execution. When the child flow has `cancel-in-progress` concurrency, the 2nd spawn's child cancels the 1st (same concurrency key), and the parent step — bound to the 1st child — fails with `NagiCanceledError`. The run **self-supersedes**.

### Prod evidence (lymo `videoAnalysis`, run `27049564`, 2026-05-29)
The parent spawned `dealAnalysis` + `dealScoring` **twice** (all four children share `parent_run_id = 27049564`, `source="videoAnalysis"` → identical key `videoAnalysis:<videoId>`); the 2nd pass cancelled the 1st; the `insights`/`dealScore` steps failed → run `failed`, even though every other step **and** the superseding subflows completed. **16 such failures in 3 days, spiking to 14 on 2026-05-28** under worker starvation (slow parent re-processing → redelivery).

## Fix

`startChildRun` now derives the child `runId` deterministically from `(parentRunId, stepId, attempt)` via `deriveChildRunId` (async, Web-Crypto SHA-256 → RFC-4122 v5-shaped `run-<uuid>`, matching `canonicalize.ts`), and **re-attaches on an existing id** instead of throwing the old `collided` error.

This works because `tryStartRun` (both `store.ts` paths) checks run **existence before** its concurrency-cancel pass, returning `{ started: false, canceled: [] }` for an existing id. So a re-delivery of the same `(parentRunId, stepId, attempt)`:
- re-derives the same id → re-attaches, **cancelling nothing**, leaving the original child + its `parent_run_id`/`parent_step_id` link intact.

Preserved behaviors:
- A **genuinely new parent** run still gets a different id → still supersedes the stale child (intended "newer wins").
- A **genuine retry** (new `attempt`) still gets a fresh child.

## Tests
- `core/src/tests/run-id.test.ts` — `deriveChildRunId` determinism / uniqueness / shape.
- `core/src/tests/subflow.test.ts` — self-supersede regression: two `startChildRun` calls → **one** child, not cancelled, same id (fails on the old random-id code).
- `postgres/src/integration.test.ts` — PG-level re-attach proof (gated on `NAGI_POSTGRES_TEST_URL`).

Verified: typecheck clean (core + postgres); core **894 pass**; postgres **81 pass / 32 gated-skip**; both packages build clean.

> No version bump in this PR — `@nagi-js/*` stays at rc14; an rc15 + consumer bump will follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)