### PR TITLE
Worker resilience hardening: no unbounded waits, no loop-fatal awaits, no unbounded poison

### DIFF
--- a/.changeset/inspect-queue.md
+++ b/.changeset/inspect-queue.md
@@ -1,0 +1,6 @@
+---
+"@nagi-js/core": minor
+"@nagi-js/pgmq": minor
+---
+
+Operator plane: `wf.inspectQueue(runId)` — read-only triage view of a run's in-queue messages (stepId, attempt, readCount, visibleAt) via optional `Queue.inspect()`; implemented for pgmq and the in-memory queue. Together with `wf.describe()` this replaces the hand-run SQL triage recipes; docs/OPERATIONS.md is the runbook.

--- a/.changeset/non-retryable-error.md
+++ b/.changeset/non-retryable-error.md
@@ -1,0 +1,5 @@
+---
+"@nagi-js/core": minor
+---
+
+`NagiNonRetryableError`: throw from a step to fail immediately, skipping the remaining retry budget. Honored anywhere on the cause chain.

--- a/.changeset/per-flow-concurrency.md
+++ b/.changeset/per-flow-concurrency.md
@@ -1,0 +1,6 @@
+---
+"@nagi-js/core": minor
+"@nagi-js/pgmq": minor
+---
+
+Per-flow blast-radius bound: `WorkerConfig.maxConcurrencyPerFlow` caps the worker slots any single flow may hold; over-cap messages defer via delayed nack. `flowId` now rides the message envelope (stamped at every enqueue path incl. lease-reap; absent pre-upgrade messages are exempt). Multi-flow deployments should set the cap ≤ concurrency − 1 so one wedged flow can never occupy the whole pool.

--- a/.changeset/poison-snapshot-gone.md
+++ b/.changeset/poison-snapshot-gone.md
@@ -1,0 +1,6 @@
+---
+"@nagi-js/core": minor
+"@nagi-js/pgmq": minor
+---
+
+Bound snapshot-gone redelivery. `QueueMessage.readCount` (pgmq `read_ct`) now travels with every delivery; the worker consults a `SnapshotGonePolicy(readCount)` — retry = delayed nack for the rolling-deploy window, then terminally fail the run with the real error and ack. Terminal runs' messages are acked at dispatch (a canceled run can no longer nack-loop). Default policy: quadratic backoff capped at 5 min, fail past 60 deliveries (~4.2h window).

--- a/.changeset/required-signal-timeout.md
+++ b/.changeset/required-signal-timeout.md
@@ -1,0 +1,5 @@
+---
+"@nagi-js/core": minor
+---
+
+BREAKING: `b.signal` now requires `timeoutMs: Millis | "unbounded"` — unbounded parking must be an explicit opt-in, never an omission. `"unbounded"` canonicalizes as omission, so existing flows keep their hashes (and in-flight runs) when migrating a timeout-less signal to `"unbounded"`. Also BREAKING: the unenforced `timeoutMs` knob is removed from task/activity/streaming/subflow configs (it armed nothing; a flow that set it changes hash on upgrade). New lease-hold watchdog: `leaseHoldWarnMs` (default 5 min, 0 disables) warns whenever a step body holds a worker slot past each threshold multiple.

--- a/.changeset/worker-dequeue-backoff.md
+++ b/.changeset/worker-dequeue-backoff.md
@@ -1,0 +1,18 @@
+---
+"@nagi-js/core": patch
+---
+
+Worker loop survives transient queue failures. A rejected `queue.dequeue` used
+to propagate out of `worker.run()` and terminate the poll loop: a single
+`pg-pool` connection timeout inside `pgmq.read` silently stopped ALL flow
+processing in a process that stayed otherwise healthy — no steps scheduled, no
+messages consumed, and no signal until stuck-run alerts fired hours later.
+
+`run()` now catches dequeue failures, logs `worker.dequeue failed; backing off`
+(with `consecutiveFailures` and `backoffMs`), sleeps, and keeps polling —
+exponential from `pollIntervalMs`, capped at 30s, reset on the first success.
+Its contract is now explicit: `run()` settles only via the abort signal.
+
+`runOnce()` / `runUntilEmpty()` are unchanged and still reject on queue
+failure — they are bounded drains whose caller is awaiting a result, so a
+rejection there is observed rather than silent.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,27 @@
 
 Type-safe, declarative workflow library for TypeScript. Define DAGs as code; the runtime owns retry, idempotency, and durability so handlers stay focused on domain logic.
 
+## Waiting on external facts
+
+A step that waits for something outside the run — a webhook, a row another
+service writes, a transcript settling — must be a `b.signal` step, never an
+in-step poll loop. A parked signal holds **no worker slot**; a polling task
+body holds its slot for the whole wait, and a handful of them can starve the
+entire worker pool (this has caused a multi-day production outage).
+
+Two guardrails enforce this:
+
+- `b.signal` requires `timeoutMs` — a deadline that fails the step as
+  `NagiSignalTimeoutError`, or the explicit `"unbounded"` opt-in. There is no
+  default: parking forever must be a written decision.
+- The lease-hold watchdog (`leaseHoldWarnMs`, default 5 min) warns every time
+  a step body holds a worker slot for another threshold multiple, so an
+  accidental in-step wait announces itself long before the pool wedges.
+
+For inputs that can never succeed (an orphaned webhook with no owning row),
+throw `NagiNonRetryableError` — the step fails immediately instead of burning
+its retry budget reaching the same terminal state.
+
 ## License
 
 [MIT](./LICENSE)

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -21,6 +21,28 @@ const q = await wf.inspectQueue(runId); // in-queue messages for the run
 | running, no lease, no entries     | —                              | Advance was lost — `operator().retry(runId, stepId)` re-drives   |
 | any status                        | entry with high `readCount`    | Redelivery loop — see poison messages below                      |
 
+## Nothing is being consumed (fleet-wide stall)
+
+Every flow stuck at once, `inspectQueue` entries all at `readCount: 0`, no live
+leases: the worker loop itself is not polling. `worker.run()` settles **only**
+via its abort signal — queue failures are logged as
+`worker.dequeue failed; backing off` and retried (exponential from
+`pollIntervalMs`, capped at 30s, reset on success), so a database blip can no
+longer end it.
+
+If the loop does exit, something outside that guard threw. `nagi.run()` logs
+`nagi.run: worker exited unexpectedly`; it does **not** restart the loop, so
+supervise it:
+
+- Page on `nagi.run: worker exited unexpectedly` (or restart `worker.run()` in
+  a loop if you drive the worker yourself).
+- Alert on oldest-unread-message age in the queue. That catches any
+  consumption stall, whatever the cause — including ones no log line covers.
+
+Sustained `worker.dequeue failed; backing off` at `error` level means the queue
+is unreachable, not that runs are broken; the loop resumes on its own once the
+queue comes back.
+
 ## Poison messages / snapshot-gone (deploy replaced an in-flight flow)
 
 Self-healing since the snapshot-gone policy: the worker retries with backoff

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,71 @@
+# Operations runbook
+
+Triage and recovery for nagi runs, using the built-in API — no hand-run SQL.
+Every recipe here previously existed only as incident folklore; the API calls
+are the supported path.
+
+## Triage a stuck run
+
+Start with two calls:
+
+```ts
+const desc = await wf.describe(runId); // run + steps + lease state
+const q = await wf.inspectQueue(runId); // in-queue messages for the run
+```
+
+| describe() says                   | inspectQueue() says            | Diagnosis                                                        |
+| --------------------------------- | ------------------------------ | ---------------------------------------------------------------- |
+| running, 0 started steps          | entry with `readCount: 0`      | Never scheduled — workers starved or not consuming               |
+| running, step has live `lease`    | entry with future `visibleAt`  | Actively executing (slow handler — watch for watchdog warns)     |
+| running, signal step `running`    | no entries                     | Parked on a signal/child — check the signal source, not the pool |
+| running, no lease, no entries     | —                              | Advance was lost — `operator().retry(runId, stepId)` re-drives   |
+| any status                        | entry with high `readCount`    | Redelivery loop — see poison messages below                      |
+
+## Poison messages / snapshot-gone (deploy replaced an in-flight flow)
+
+Self-healing since the snapshot-gone policy: the worker retries with backoff
+for the rolling-deploy window, then **terminally fails the run** with
+`NagiFlowSnapshotGoneError` in `workflow_run.error` and acks the message.
+Nothing loops forever.
+
+Intervene earlier if needed:
+
+- `wf.cancel(runId)` — fact-only, bypasses the flow registry, and the
+  dispatcher acks a terminal run's messages on next delivery. One call; no
+  queue surgery.
+- To re-run the work on current code: start a fresh run (concurrency
+  cancel-in-progress supersedes the dead one).
+
+Tune via `WorkerConfig.snapshotGonePolicy`; wrap `defaultSnapshotGonePolicy`
+to widen/narrow the retry window.
+
+## Permanently-unprocessable input
+
+Throw `NagiNonRetryableError` (anywhere on the cause chain) from the step —
+the step fails on that attempt without consuming the remaining retry budget.
+Use for orphaned webhooks, schema-invalid payloads, deleted parents.
+
+## Wedged worker pool
+
+Prevention layers, in order:
+
+1. `b.signal` requires a timeout — external waits park (no slot held) and
+   fail honestly as `NagiSignalTimeoutError` when the input never arrives.
+2. The lease-hold watchdog (`leaseHoldWarnMs`, default 5 min) warns every
+   threshold multiple a step body holds a slot — grep for
+   `holding a worker slot` before the pool saturates.
+3. `WorkerConfig.maxConcurrencyPerFlow` (multi-flow deployments: set it to at
+   most `concurrency - 1`) keeps one flow from occupying every slot.
+
+## Operator actions
+
+`wf.operator()` (all take `{ actor, note? }` for the audit trail):
+
+- `skip(runId, stepId)` — settle a step as skipped and advance past it.
+- `retry(runId, stepId)` — abort if running, reset the step **and its
+  descendants**, re-dispatch. (Non-cascading single-step rerun is tracked in
+  issue #34.)
+- `abort(runId)` — cancel the run and its children, recursively.
+
+Plus `wf.replay(runId, { mode, from })` for whole-run replay on the current
+flow version, and `wf.cancel(runId)` for a plain stop.

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -53,7 +53,6 @@ function makeBuilder<Input>(): Builder<Input> {
       run: config.run as TaskDef["run"],
       ...compact({
         retry: config.retry,
-        timeoutMs: config.timeoutMs,
         when: config.when as TaskDef["when"],
         onStart: config.onStart,
         onComplete: config.onComplete as TaskDef["onComplete"],
@@ -73,7 +72,6 @@ function makeBuilder<Input>(): Builder<Input> {
       run: config.run as ActivityDef["run"],
       ...compact({
         retry: config.retry,
-        timeoutMs: config.timeoutMs,
         when: config.when as ActivityDef["when"],
         onStart: config.onStart,
         onComplete: config.onComplete as ActivityDef["onComplete"],
@@ -93,7 +91,6 @@ function makeBuilder<Input>(): Builder<Input> {
       run: config.run as StreamingTaskDef["run"],
       ...compact({
         retry: config.retry,
-        timeoutMs: config.timeoutMs,
         when: config.when as StreamingTaskDef["when"],
         onStart: config.onStart,
         onComplete: config.onComplete as StreamingTaskDef["onComplete"],
@@ -111,9 +108,9 @@ function makeBuilder<Input>(): Builder<Input> {
       kind: "signal",
       needs: normalizeNeeds(config.needs),
       schema: config.schema,
+      timeoutMs: config.timeoutMs,
       ...compact({
         names: config.names,
-        timeoutMs: config.timeoutMs,
         when: config.when as SignalDef["when"],
       }),
     };
@@ -130,7 +127,6 @@ function makeBuilder<Input>(): Builder<Input> {
       childFlowId: child.id,
       buildInput: config.input as SubflowDef["buildInput"],
       ...compact({
-        timeoutMs: config.timeoutMs,
         when: config.when as SubflowDef["when"],
       }),
     };

--- a/packages/core/src/canonicalize.ts
+++ b/packages/core/src/canonicalize.ts
@@ -121,10 +121,14 @@ async function canonicalizeStep(
 // Key insertion order is irrelevant to the flow hash: stableStringify sorts keys.
 async function applyGuardAndTimeout(
   out: Mutable<CanonicalStep>,
-  def: { readonly when?: Guard; readonly timeoutMs?: Millis },
+  def: { readonly when?: Guard; readonly timeoutMs?: Millis | "unbounded" },
 ): Promise<void> {
   if (def.when !== undefined) out.whenHash = await hashFnSource(def.when);
-  if (def.timeoutMs !== undefined) out.timeoutMs = def.timeoutMs;
+  // "unbounded" canonicalizes as omission: it is semantically identical to the
+  // pre-required-timeout absence, so flows keep their hashes (and their
+  // in-flight runs) across the API migration.
+  if (def.timeoutMs !== undefined && def.timeoutMs !== "unbounded")
+    out.timeoutMs = def.timeoutMs;
 }
 
 async function canonicalizeTask(

--- a/packages/core/src/dispatch.ts
+++ b/packages/core/src/dispatch.ts
@@ -22,6 +22,7 @@ import type {
 export interface HeartbeatConfig {
   readonly intervalMs: Millis;
   readonly leaseMs: Millis;
+  readonly holdWarnMs: Millis;
 }
 
 export interface DispatchDeps {

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -24,6 +24,19 @@ export class NagiRuntimeError extends Error {
   }
 }
 
+// Marks a failure as permanently unprocessable: classifyFailure fails the step
+// immediately, skipping the remaining retry budget. For inputs where retrying
+// cannot succeed (an orphaned webhook with no owning row, a schema-invalid
+// payload) — without this, a permanent failure burns every retry before
+// reaching the same terminal state. Wrap the underlying error as `cause`; the
+// marker is honored anywhere on the cause chain, so it survives SDK wrapping.
+export class NagiNonRetryableError extends Error {
+  constructor(message: string, opts?: { readonly cause?: unknown }) {
+    super(message, opts);
+    this.name = "NagiNonRetryableError";
+  }
+}
+
 export class NagiCanceledError extends Error {
   readonly runId: RunId;
   readonly canceledByRunId: RunId;

--- a/packages/core/src/exec/message.ts
+++ b/packages/core/src/exec/message.ts
@@ -119,6 +119,7 @@ export function makeMessage(
       receipt: message.receipt,
       intervalMs: deps.heartbeat.intervalMs,
       leaseMs: deps.heartbeat.leaseMs,
+      holdWarnMs: deps.heartbeat.holdWarnMs,
       emitLog: deps.emitLog,
     });
     let outcome: Dispatched;
@@ -193,8 +194,9 @@ export function makeMessage(
     // records, so the deadline is derived from a persisted fact (replay-safe),
     // never from a fresh clock read. upsertTimer keeps the earliest deadline, so
     // a lease-reap re-dispatch of a still-parked signal doesn't push it out.
-    // Steps without timeoutMs park forever as before.
-    if (def.kind === "signal" && def.timeoutMs != null) {
+    // timeoutMs: "unbounded" is the (explicit, config-level) opt-in to parking
+    // forever — the only way to get a timer-less wait.
+    if (def.kind === "signal" && typeof def.timeoutMs === "number") {
       await store.upsertTimer(
         runId,
         stepId,

--- a/packages/core/src/exec/message.ts
+++ b/packages/core/src/exec/message.ts
@@ -619,6 +619,7 @@ export function makeMessage(
         await queue.enqueue(runId, stepId, {
           attempt: attempt + 1,
           delayMs: outcome.delayMs,
+          flowId: flow.id,
         });
         return { tag: "parked" };
       }

--- a/packages/core/src/exec/message.ts
+++ b/packages/core/src/exec/message.ts
@@ -1,5 +1,5 @@
 import type { DispatchDeps } from "../dispatch";
-import { serializeError } from "../errors";
+import { NagiFlowSnapshotGoneError, serializeError } from "../errors";
 import { Facts } from "../facts";
 import {
   asStepMapWithDefs,
@@ -79,7 +79,23 @@ export function makeMessage(
 
   async function dispatchMessage(message: QueueMessage): Promise<void> {
     const { queue } = deps;
-    const flow = await deps.flowFor(message.runId);
+    let flow: Flow;
+    try {
+      flow = await deps.flowFor(message.runId);
+    } catch (err) {
+      // A terminal run's message must not outlive it: without this, a run
+      // canceled AFTER its flow snapshot went gone (deploy replaced the flow
+      // mid-flight) would nack-loop forever, because the hash check fires
+      // before admit()'s canceled-phase check ever runs.
+      if (
+        err instanceof NagiFlowSnapshotGoneError &&
+        isTerminalRun(await deps.store.loadRunState(message.runId))
+      ) {
+        await queue.ack(message.receipt);
+        return;
+      }
+      throw err;
+    }
 
     const admission = await admit({ flow, message });
     if (admission.tag === "skip") {

--- a/packages/core/src/exec/progression.ts
+++ b/packages/core/src/exec/progression.ts
@@ -111,7 +111,8 @@ export function makeProgression(deps: DispatchDeps, hooks: Hooks): Progression {
           return;
         case "dispatch":
           await recordSkips(runId, t.skip);
-          for (const stepId of t.runnable) await queue.enqueue(runId, stepId);
+          for (const stepId of t.runnable)
+            await queue.enqueue(runId, stepId, { flowId: flow.id });
           return;
         case "skip":
           await recordSkips(runId, t.skip);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,7 @@ export {
   NagiCanceledError,
   NagiConcurrencyConflictError,
   NagiFlowSnapshotGoneError,
+  NagiNonRetryableError,
   NagiRuntimeError,
   NagiSignalTimeoutError,
   NagiSnapshotDriftError,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -165,6 +165,8 @@ export type {
   SignalReceivedFact,
   SignalSentEvent,
   SignalSentFact,
+  SnapshotGoneDisposition,
+  SnapshotGonePolicy,
   StandardSchemaV1,
   Step,
   StepAbortRequestedFact,
@@ -204,3 +206,4 @@ export type {
   WorkerRunResult,
   WorkerRunUntilEmptyOpts,
 } from "./types";
+export { defaultSnapshotGonePolicy } from "./worker";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -149,6 +149,7 @@ export type {
   Queue,
   QueueDequeueOpts,
   QueueEnqueueOpts,
+  QueueInspectEntry,
   QueueMessage,
   Register,
   ReplayMode,

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -80,7 +80,6 @@ export interface TaskDef extends StepLifecycleHooks<Json> {
   readonly kind: "task";
   readonly needs: NeedsDefMap;
   readonly retry?: RetryPolicy;
-  readonly timeoutMs?: Millis;
   readonly when?: Guard;
   readonly run: (args: {
     input: unknown;
@@ -98,7 +97,6 @@ export interface ActivityDef extends StepLifecycleHooks<Json> {
   readonly kind: "activity";
   readonly needs: NeedsDefMap;
   readonly retry?: RetryPolicy;
-  readonly timeoutMs?: Millis;
   readonly when?: Guard;
   readonly run: (args: {
     input: unknown;
@@ -112,7 +110,6 @@ export interface StreamingTaskDef extends StepLifecycleHooks<Json> {
   readonly kind: "streaming";
   readonly needs: NeedsDefMap;
   readonly retry?: RetryPolicy;
-  readonly timeoutMs?: Millis;
   readonly when?: Guard;
   readonly run: (args: {
     input: unknown;
@@ -127,7 +124,7 @@ export interface SignalDef {
   readonly needs: NeedsDefMap;
   readonly schema: StandardSchemaV1;
   readonly names?: readonly [string, ...string[]];
-  readonly timeoutMs?: Millis;
+  readonly timeoutMs: Millis | "unbounded";
   readonly when?: Guard;
   readonly parentMatch?: ParentMatchRef;
 }
@@ -163,7 +160,6 @@ export interface SubflowDef {
   readonly needs: NeedsDefMap;
   readonly childFlowId: string;
   readonly buildInput: (args: GuardArgs) => unknown;
-  readonly timeoutMs?: Millis;
   readonly when?: Guard;
   readonly parentMatch?: ParentMatchRef;
 }

--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -335,6 +335,7 @@ export class InMemoryStore implements Store, StreamTransport {
       await queue.enqueue(c.runId, c.stepId, {
         attempt: decision.nextAttempt,
         delayMs: decision.backoffMs,
+        ...(state?.flowId !== undefined ? { flowId: state.flowId } : {}),
       });
       reaped.push({
         runId: c.runId,
@@ -901,6 +902,7 @@ export class InMemoryQueue implements Queue {
       readCount: 0,
       enqueuedAt: now,
       visibleAt: now + (opts?.delayMs ?? 0),
+      ...(opts?.flowId !== undefined ? { flowId: opts.flowId } : {}),
     };
     this.pending.push(item);
   }

--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -898,6 +898,7 @@ export class InMemoryQueue implements Queue {
       stepId,
       payload: opts?.payload ?? null,
       attempt: opts?.attempt ?? 1,
+      readCount: 0,
       enqueuedAt: now,
       visibleAt: now + (opts?.delayMs ?? 0),
     };
@@ -915,11 +916,15 @@ export class InMemoryQueue implements Queue {
       const item = this.pending[i];
       if (item === undefined) continue;
       if (item.visibleAt > now) continue;
-      const next: QueuedItem = { ...item, visibleAt: now + this.leaseMs };
+      const delivered: QueuedItem = {
+        ...item,
+        readCount: item.readCount + 1,
+        visibleAt: now + this.leaseMs,
+      };
       this.pending.splice(i, 1);
       i--;
-      this.leased.set(item.receipt, next);
-      claimed.push(item);
+      this.leased.set(item.receipt, delivered);
+      claimed.push(delivered);
     }
     return claimed;
   }

--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -37,6 +37,7 @@ import type {
   Queue,
   QueueDequeueOpts,
   QueueEnqueueOpts,
+  QueueInspectEntry,
   QueueMessage,
   RunId,
   RunState,
@@ -950,6 +951,18 @@ export class InMemoryQueue implements Queue {
     const item = this.leased.get(receipt);
     if (!item) return;
     this.leased.set(receipt, { ...item, visibleAt: Date.now() + leaseMs });
+  }
+
+  async inspect(runId: RunId): Promise<readonly QueueInspectEntry[]> {
+    const all = [...this.pending, ...this.leased.values()];
+    return all
+      .filter((m) => m.runId === runId)
+      .map((m) => ({
+        stepId: m.stepId,
+        attempt: m.attempt,
+        readCount: m.readCount,
+        visibleAt: new Date(m.visibleAt),
+      }));
   }
 }
 

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -26,6 +26,7 @@ import { foldRun, isTerminalRun, runStatusOf } from "./state";
 import {
   DEFAULT_HEARTBEAT_INTERVAL_MS,
   DEFAULT_HEARTBEAT_LEASE_MS,
+  DEFAULT_LEASE_HOLD_WARN_MS,
 } from "./step-exec";
 import type {
   CancelArgs,
@@ -77,6 +78,12 @@ export interface NagiConfig {
   // or a slow step's message is redelivered before the first lease extension.
   readonly heartbeatIntervalMs?: Millis;
   readonly heartbeatLeaseMs?: Millis;
+  // Warn each time a step body has held a worker slot for another multiple of
+  // this (default 5 min; 0 disables). A firing watchdog usually means an
+  // in-step wait on an external fact — model those as b.signal steps, which
+  // park WITHOUT holding a slot. Timeout-less in-step waits have starved
+  // entire worker pools in production.
+  readonly leaseHoldWarnMs?: Millis;
   // Lease-reaper sweep cadence. Default 30s — stay ≤ ½ the store lease TTL so
   // a crashed worker is reaped within one TTL. 0 disables the reaper (tests,
   // or external/cron-driven reaping).
@@ -444,6 +451,7 @@ async function nagiImpl<const TFlows extends ReadonlyArray<Flow>>(
     heartbeat: {
       intervalMs: config.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS,
       leaseMs: config.heartbeatLeaseMs ?? DEFAULT_HEARTBEAT_LEASE_MS,
+      holdWarnMs: config.leaseHoldWarnMs ?? DEFAULT_LEASE_HOLD_WARN_MS,
     },
     ...compact({
       hooks: config.hooks,

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -589,7 +589,7 @@ async function nagiImpl<const TFlows extends ReadonlyArray<Flow>>(
         if (transition.kind === "dispatch") {
           const txQueue = bindQueueToTx(config.queue, opts.tx);
           for (const stepId of transition.runnable) {
-            await txQueue.enqueue(runId, stepId);
+            await txQueue.enqueue(runId, stepId, { flowId: flow.id });
           }
         }
       }

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -47,6 +47,7 @@ import type {
   QueryRunsOpts,
   QueryRunsResult,
   Queue,
+  QueueInspectEntry,
   ReplayOpts,
   RetryPolicy,
   RunId,
@@ -162,6 +163,13 @@ export interface Wf<TFlows extends ReadonlyArray<Flow> = ReadonlyArray<Flow>> {
   // for an unknown runId (never throws). Parent/children are nested on the
   // returned RunView; the outer envelope is `{run, steps}` only.
   describe(runId: RunId): Promise<RunDescription>;
+
+  // Read-only triage view of the run's in-queue messages, complementing
+  // describe(): a non-terminal run with pending steps and NO queue entries was
+  // never scheduled (worker starvation); a future visibleAt is leased/delayed;
+  // a high readCount is a redelivery loop. Throws NagiRuntimeError when the
+  // queue adapter doesn't implement inspect().
+  inspectQueue(runId: RunId): Promise<readonly QueueInspectEntry[]>;
 
   subscribe<C = Json>(
     runId: RunId,
@@ -685,6 +693,15 @@ async function nagiImpl<const TFlows extends ReadonlyArray<Flow>>(
 
     async describe(runId: RunId): Promise<RunDescription> {
       return config.store.describe(runId);
+    },
+
+    async inspectQueue(runId: RunId): Promise<readonly QueueInspectEntry[]> {
+      if (config.queue.inspect === undefined) {
+        throw new NagiRuntimeError(
+          "inspectQueue: the configured queue adapter does not implement inspect().",
+        );
+      }
+      return config.queue.inspect(runId);
     },
 
     async queryRuns(opts: QueryRunsOpts = {}): Promise<QueryRunsResult> {

--- a/packages/core/src/step-exec.ts
+++ b/packages/core/src/step-exec.ts
@@ -1,4 +1,4 @@
-import { NagiCanceledError } from "./errors";
+import { NagiCanceledError, NagiNonRetryableError } from "./errors";
 import { Facts } from "./facts";
 import { makeIdempotencyKey, makeOnce } from "./idempotency";
 import type { EmitLog } from "./internal";
@@ -246,7 +246,7 @@ export function classifyFailure(args: {
       includeError: isAbort,
     };
   }
-  const cancel = findNagiCanceledError(err);
+  const cancel = findInCauseChain(err, NagiCanceledError);
   if (cancel !== undefined) {
     return {
       tag: "flowCanceled",
@@ -254,20 +254,26 @@ export function classifyFailure(args: {
       concurrencyKey: cancel.concurrencyKey,
     };
   }
+  if (findInCauseChain(err, NagiNonRetryableError) !== undefined) {
+    return { tag: "failed" };
+  }
   if (attempt < policy.maxAttempts && retryAllows(policy, err)) {
     return { tag: "retry", delayMs: computeBackoff(policy, attempt) };
   }
   return { tag: "failed" };
 }
 
-// Walk the error cause chain looking for a real NagiCanceledError instance.
+// Walk the error cause chain looking for a real instance of the given class.
 // Requiring the class (not just shape) defends against forged JSONB cause data
 // re-thrown as plain Errors.
-function findNagiCanceledError(err: unknown): NagiCanceledError | undefined {
+function findInCauseChain<T extends Error>(
+  err: unknown,
+  ctor: new (...args: never[]) => T,
+): T | undefined {
   let cursor: unknown = err;
   const seen = new Set<unknown>();
   while (cursor instanceof Error && !seen.has(cursor)) {
-    if (cursor instanceof NagiCanceledError) return cursor;
+    if (cursor instanceof ctor) return cursor;
     seen.add(cursor);
     cursor = (cursor as { cause?: unknown }).cause;
   }

--- a/packages/core/src/step-exec.ts
+++ b/packages/core/src/step-exec.ts
@@ -137,6 +137,11 @@ export function startCancelWatcher(args: {
 
 export const DEFAULT_HEARTBEAT_LEASE_MS: Millis = 120_000;
 export const DEFAULT_HEARTBEAT_INTERVAL_MS: Millis = 40_000;
+// A step body holding a worker slot this long is either a legitimately slow
+// handler or an in-step wait on an external fact (a poll loop) that should be
+// a b.signal step — parked signals hold no slot. Warn on every crossing so a
+// wedged pool announces itself long before it exhausts worker concurrency.
+export const DEFAULT_LEASE_HOLD_WARN_MS: Millis = 300_000;
 
 // Keeps an in-flight step's queue message invisible while its handler runs. A
 // long handler (e.g. a multi-minute LLM call) otherwise outlives the queue's
@@ -163,6 +168,9 @@ export function startHeartbeat(args: {
   readonly receipt: string;
   readonly intervalMs: Millis;
   readonly leaseMs: Millis;
+  // Warn each time a step has held its worker slot for another multiple of
+  // this. 0 disables (tests). See DEFAULT_LEASE_HOLD_WARN_MS.
+  readonly holdWarnMs: Millis;
   readonly emitLog: EmitLog;
 }): { readonly stop: () => void } {
   const {
@@ -174,14 +182,29 @@ export function startHeartbeat(args: {
     receipt,
     intervalMs,
     leaseMs,
+    holdWarnMs,
     emitLog,
   } = args;
   let stopped = false;
   let timer: ReturnType<typeof setTimeout> | undefined;
+  const startedAtMs = Date.now();
+  let warnedCrossings = 0;
 
   const schedule = (): void => {
     timer = setTimeout(() => {
       void (async () => {
+        if (holdWarnMs > 0) {
+          const heldMs = Date.now() - startedAtMs;
+          const crossings = Math.floor(heldMs / holdWarnMs);
+          if (crossings > warnedCrossings) {
+            warnedCrossings = crossings;
+            emitLog({
+              level: "warn",
+              msg: "heartbeat: step is holding a worker slot unusually long — slow handler, or an in-step wait that should be a b.signal step?",
+              attrs: { runId, stepId, attempt, heldMs },
+            });
+          }
+        }
         await Promise.all([
           queue.extend(receipt, leaseMs).catch((err: unknown) => {
             // A missed extension only risks an early redelivery, which admit()'s

--- a/packages/core/src/tests/builder.test.ts
+++ b/packages/core/src/tests/builder.test.ts
@@ -119,7 +119,10 @@ describe("flow()", () => {
       input: passthroughSchema<Record<string, never>>(),
       build: (b) => {
         const t = b.task({ run: async () => null });
-        const s = b.signal({ schema: passthroughSchema<{ ok: boolean }>() });
+        const s = b.signal({
+          timeoutMs: "unbounded" as const,
+          schema: passthroughSchema<{ ok: boolean }>(),
+        });
         return { t, s };
       },
     });

--- a/packages/core/src/tests/canonicalize.test.ts
+++ b/packages/core/src/tests/canonicalize.test.ts
@@ -237,22 +237,45 @@ describe("canonicalize — byte-difference invariants (different hash)", () => {
     expect(await hashOf(f1)).not.toBe(await hashOf(f2));
   });
 
-  it("differs when timeoutMs changes", async () => {
+  it("differs when a signal's timeoutMs changes", async () => {
     const f1 = flow({
       id: "timeout",
       input: passthroughSchema<Record<string, never>>(),
       build: (b) => ({
-        only: b.task({ timeoutMs: 1000, run: async () => null }),
+        only: b.signal({
+          timeoutMs: 1000,
+          schema: passthroughSchema<{ v: number }>(),
+        }),
       }),
     });
     const f2 = flow({
       id: "timeout",
       input: passthroughSchema<Record<string, never>>(),
       build: (b) => ({
-        only: b.task({ timeoutMs: 5000, run: async () => null }),
+        only: b.signal({
+          timeoutMs: 5000,
+          schema: passthroughSchema<{ v: number }>(),
+        }),
       }),
     });
     expect(await hashOf(f1)).not.toBe(await hashOf(f2));
+  });
+
+  it('timeoutMs: "unbounded" canonicalizes as omission (hash-stable across the required-timeout migration)', async () => {
+    const f = flow({
+      id: "timeout-unbounded",
+      input: passthroughSchema<Record<string, never>>(),
+      build: (b) => ({
+        only: b.signal({
+          timeoutMs: "unbounded",
+          schema: passthroughSchema<{ v: number }>(),
+        }),
+      }),
+    });
+    const dag = await canonicalize(f);
+    const only = dag.steps.find((s) => s.id === "only");
+    expect(only).toBeDefined();
+    expect(only).not.toHaveProperty("timeoutMs");
   });
 
   it("differs when a signal schema validator body changes", async () => {
@@ -261,6 +284,7 @@ describe("canonicalize — byte-difference invariants (different hash)", () => {
       input: passthroughSchema<Record<string, never>>(),
       build: (b) => ({
         s: b.signal({
+          timeoutMs: "unbounded" as const,
           schema: {
             "~standard": {
               version: 1 as const,
@@ -276,6 +300,7 @@ describe("canonicalize — byte-difference invariants (different hash)", () => {
       input: passthroughSchema<Record<string, never>>(),
       build: (b) => ({
         s: b.signal({
+          timeoutMs: "unbounded" as const,
           schema: {
             "~standard": {
               version: 1 as const,
@@ -300,6 +325,7 @@ describe("canonicalize — byte-difference invariants (different hash)", () => {
       input: passthroughSchema<Record<string, never>>(),
       build: (b) => ({
         s: b.signal({
+          timeoutMs: "unbounded" as const,
           schema: {
             "~standard": {
               version: 1 as const,
@@ -315,6 +341,7 @@ describe("canonicalize — byte-difference invariants (different hash)", () => {
       input: passthroughSchema<Record<string, never>>(),
       build: (b) => ({
         s: b.signal({
+          timeoutMs: "unbounded" as const,
           schema: {
             "~standard": {
               version: 1 as const,

--- a/packages/core/src/tests/dequeue-resilience.test.ts
+++ b/packages/core/src/tests/dequeue-resilience.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+import { flow } from "../builder";
+import { InMemoryClock, InMemoryQueue, InMemoryStore } from "../memory";
+import { nagi } from "../runtime";
+import type {
+  LogEntry,
+  Millis,
+  Queue,
+  QueueDequeueOpts,
+  QueueEnqueueOpts,
+  QueueMessage,
+  RunId,
+  StepId,
+} from "../types";
+import { emptySchema } from "./test-helpers";
+
+// Rejects the first `failures` dequeue calls, then delegates. Models the prod
+// trigger: a transient pg connection timeout inside pgmq.read.
+class FlakyDequeueQueue implements Queue {
+  dequeueCalls = 0;
+  constructor(
+    private readonly inner: InMemoryQueue,
+    private readonly failures: number,
+  ) {}
+  async enqueue(
+    runId: RunId,
+    stepId: StepId,
+    opts?: QueueEnqueueOpts,
+  ): Promise<void> {
+    return this.inner.enqueue(runId, stepId, opts);
+  }
+  async dequeue(opts: QueueDequeueOpts): Promise<readonly QueueMessage[]> {
+    this.dequeueCalls++;
+    if (this.dequeueCalls <= this.failures) {
+      throw new Error("Connection terminated due to connection timeout");
+    }
+    return this.inner.dequeue(opts);
+  }
+  async ack(receipt: string): Promise<void> {
+    return this.inner.ack(receipt);
+  }
+  async nack(receipt: string, opts?: { delayMs?: Millis }): Promise<void> {
+    return this.inner.nack(receipt, opts);
+  }
+  async extend(receipt: string, leaseMs: Millis): Promise<void> {
+    return this.inner.extend(receipt, leaseMs);
+  }
+}
+
+const noop = flow({
+  id: "noop",
+  input: emptySchema(),
+  build: (b) => ({ s: b.task({ run: async () => ({ ok: true }) }) }),
+});
+
+async function waitFor(
+  predicate: () => Promise<boolean>,
+  message: string,
+): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  for (;;) {
+    if (await predicate()) return;
+    if (Date.now() > deadline) throw new Error(message);
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+// The outage this guards: one rejected pgmq.read terminated run(), every flow
+// stopped being scheduled, and the process stayed healthy enough that nothing
+// noticed for 37h.
+describe("worker.run dequeue resilience", () => {
+  it("survives a failing dequeue and keeps dispatching", async () => {
+    const store = new InMemoryStore();
+    const queue = new FlakyDequeueQueue(new InMemoryQueue(), 1);
+    const logs: LogEntry[] = [];
+
+    const wf = await nagi({
+      flows: [noop],
+      store,
+      queue,
+      clock: new InMemoryClock(),
+      onLog: (e) => logs.push(e),
+    });
+    const runId = await wf.start(noop, {});
+
+    const ac = new AbortController();
+    const worker = wf.worker({
+      pollIntervalMs: 5,
+      timerSweepIntervalMs: 0,
+      signal: ac.signal,
+    });
+    const loop = worker.run();
+
+    try {
+      await waitFor(
+        async () => (await store.loadRunState(runId)).phase.tag === "completed",
+        "run never completed: the loop died on the dequeue failure",
+      );
+    } finally {
+      ac.abort();
+      await loop;
+    }
+
+    expect(
+      logs.filter((l) => l.msg === "worker.dequeue failed; backing off"),
+    ).toHaveLength(1);
+  });
+
+  it("run() settles only via abort, even while dequeue never succeeds", async () => {
+    const store = new InMemoryStore();
+    const queue = new FlakyDequeueQueue(
+      new InMemoryQueue(),
+      Number.POSITIVE_INFINITY,
+    );
+    const logs: LogEntry[] = [];
+
+    const wf = await nagi({
+      flows: [noop],
+      store,
+      queue,
+      clock: new InMemoryClock(),
+      onLog: (e) => logs.push(e),
+    });
+
+    const ac = new AbortController();
+    const worker = wf.worker({
+      pollIntervalMs: 5,
+      timerSweepIntervalMs: 0,
+      signal: ac.signal,
+    });
+    let settled = false;
+    const loop = worker.run().finally(() => {
+      settled = true;
+    });
+
+    await waitFor(
+      async () => queue.dequeueCalls >= 3,
+      "loop stopped polling during a sustained outage",
+    );
+    expect(settled).toBe(false);
+
+    ac.abort();
+    await loop;
+    expect(settled).toBe(true);
+
+    // Backoff grows and is capped: base = max(pollIntervalMs, 50) = 50.
+    const backoffs = logs
+      .filter((l) => l.msg === "worker.dequeue failed; backing off")
+      .map((l) => l.attrs?.["backoffMs"]);
+    expect(backoffs.slice(0, 3)).toEqual([50, 100, 200]);
+    expect(backoffs.every((b) => (b as number) <= 30_000)).toBe(true);
+  });
+
+  it("runOnce still rejects — its caller is awaiting a result", async () => {
+    const store = new InMemoryStore();
+    const queue = new FlakyDequeueQueue(new InMemoryQueue(), 1);
+    const wf = await nagi({
+      flows: [noop],
+      store,
+      queue,
+      clock: new InMemoryClock(),
+    });
+    await wf.start(noop, {});
+
+    await expect(wf.worker().runOnce()).rejects.toThrow(
+      "Connection terminated",
+    );
+  });
+});

--- a/packages/core/src/tests/dispatch.test.ts
+++ b/packages/core/src/tests/dispatch.test.ts
@@ -151,7 +151,10 @@ describe("dispatchMessage — driver", () => {
       id: "signal-driver",
       input: passthroughSchema<Record<string, never>>(),
       build: (b) => {
-        const wait = b.signal({ schema: passthroughSchema<{ ok: boolean }>() });
+        const wait = b.signal({
+          timeoutMs: "unbounded" as const,
+          schema: passthroughSchema<{ ok: boolean }>(),
+        });
         const after = b.task({
           needs: { wait },
           run: async () => {
@@ -253,7 +256,10 @@ describe("dispatchMessage — driver", () => {
       id: "hook-signal-null",
       input: passthroughSchema<{ tag: string }>(),
       build: (b) => {
-        const wait = b.signal({ schema: passthroughSchema<{ ok: boolean }>() });
+        const wait = b.signal({
+          timeoutMs: "unbounded" as const,
+          schema: passthroughSchema<{ ok: boolean }>(),
+        });
         return { wait };
       },
     });

--- a/packages/core/src/tests/early-signal-buffering.test.ts
+++ b/packages/core/src/tests/early-signal-buffering.test.ts
@@ -9,6 +9,7 @@ function transcriptFlow() {
     input: passthroughSchema<Record<string, never>>(),
     build: (b) => ({
       transcript: b.signal({
+        timeoutMs: "unbounded" as const,
         names: ["audioReady", "recordingReady"],
         schema: passthroughSchema<
           { audioUrl: string } | { transcript: string }

--- a/packages/core/src/tests/flow-snapshot-gone.test.ts
+++ b/packages/core/src/tests/flow-snapshot-gone.test.ts
@@ -119,7 +119,10 @@ describe("NagiFlowSnapshotGoneError", () => {
       id: "signal-flow",
       input: passthroughSchema<Record<string, never>>(),
       build: (b) => ({
-        wait: b.signal({ schema: passthroughSchema<{ ok: true }>() }),
+        wait: b.signal({
+          timeoutMs: "unbounded" as const,
+          schema: passthroughSchema<{ ok: true }>(),
+        }),
       }),
     });
     const wfA = await nagi({ flows: [fA], store, queue, clock });
@@ -130,7 +133,10 @@ describe("NagiFlowSnapshotGoneError", () => {
       id: "signal-flow",
       input: passthroughSchema<Record<string, never>>(),
       build: (b) => ({
-        wait: b.signal({ schema: passthroughSchema<{ ok: true }>() }),
+        wait: b.signal({
+          timeoutMs: "unbounded" as const,
+          schema: passthroughSchema<{ ok: true }>(),
+        }),
         extra: b.task({ run: async () => ({}) }),
       }),
     });

--- a/packages/core/src/tests/flow-snapshot-gone.test.ts
+++ b/packages/core/src/tests/flow-snapshot-gone.test.ts
@@ -212,3 +212,124 @@ describe("NagiFlowSnapshotGoneError", () => {
     ).rejects.toBeInstanceOf(NagiSnapshotDriftError);
   });
 });
+
+describe("snapshot-gone poison handling", () => {
+  it("acks the message of a run canceled after its snapshot went gone (no nack loop)", async () => {
+    const store = new InMemoryStore();
+    const queue = new InMemoryQueue();
+    const clock = new InMemoryClock();
+
+    const fA = makeFlowA();
+    const wfA = await nagi({ flows: [fA], store, queue, clock });
+    const runId = await wfA.start(fA, {});
+
+    const fB = makeFlowB();
+    const wfB = await nagi({ flows: [fB], store, queue, clock });
+    await wfB.cancel(runId, { reason: "operator cleanup" });
+
+    // The policy must never be consulted: dispatchMessage acks terminal runs
+    // before the error ever reaches the worker.
+    const worker = wfB.worker({
+      timerSweepIntervalMs: 0,
+      snapshotGonePolicy: () => {
+        throw new Error("policy must not run for a terminal run");
+      },
+    });
+    const { processed } = await worker.runUntilEmpty();
+    expect(processed).toBe(1);
+
+    expect(await queue.dequeue({ count: 10 })).toHaveLength(0);
+    expect((await store.loadRunState(runId)).phase.tag).toBe("canceled");
+  });
+
+  it("retries with the policy's delay while budgeted, then terminally fails the run", async () => {
+    const store = new InMemoryStore();
+    const queue = new InMemoryQueue();
+    const clock = new InMemoryClock();
+
+    const fA = makeFlowA();
+    const wfA = await nagi({ flows: [fA], store, queue, clock });
+    const runId = await wfA.start(fA, {});
+
+    const fB = makeFlowB();
+    const wfB = await nagi({ flows: [fB], store, queue, clock });
+
+    const seenReadCounts: number[] = [];
+    const worker = wfB.worker({
+      timerSweepIntervalMs: 0,
+      snapshotGonePolicy: (readCount) => {
+        seenReadCounts.push(readCount);
+        return readCount < 3
+          ? { action: "retry", delayMs: 0 }
+          : { action: "fail" };
+      },
+    });
+    await worker.runUntilEmpty();
+
+    // Redelivery count grew across nacks; the budget fired on the 3rd read.
+    expect(seenReadCounts).toEqual([1, 2, 3]);
+    expect(await queue.dequeue({ count: 10 })).toHaveLength(0);
+
+    const state = await store.loadRunState(runId);
+    expect(state.phase.tag).toBe("failed");
+    if (state.phase.tag === "failed") {
+      expect(state.phase.error.name).toBe("NagiFlowSnapshotGoneError");
+    }
+  });
+
+  it("defaultSnapshotGonePolicy: quadratic backoff capped at 5min, fails past 60 deliveries", async () => {
+    const { defaultSnapshotGonePolicy } = await import("../worker");
+    expect(defaultSnapshotGonePolicy(1)).toEqual({
+      action: "retry",
+      delayMs: 1_000,
+    });
+    expect(defaultSnapshotGonePolicy(10)).toEqual({
+      action: "retry",
+      delayMs: 100_000,
+    });
+    // Cap: 18² = 324s exceeds the 300s ceiling.
+    expect(defaultSnapshotGonePolicy(18)).toEqual({
+      action: "retry",
+      delayMs: 300_000,
+    });
+    expect(defaultSnapshotGonePolicy(60)).toEqual({
+      action: "retry",
+      delayMs: 300_000,
+    });
+    expect(defaultSnapshotGonePolicy(61)).toEqual({ action: "fail" });
+    // The whole window is ~4.2h — above the 4h signal-timeout house constant,
+    // below 6h stuck-run alerting. Pin it so a tweak is a conscious choice.
+    let totalMs = 0;
+    for (let readCount = 1; readCount <= 60; readCount++) {
+      const d = defaultSnapshotGonePolicy(readCount);
+      if (d.action === "retry") totalMs += d.delayMs;
+    }
+    expect(totalMs).toBeGreaterThan(4 * 3_600_000);
+    expect(totalMs).toBeLessThan(6 * 3_600_000);
+  });
+
+  it("a failing policy falls back to a delayed nack instead of crashing or tight-looping", async () => {
+    const store = new InMemoryStore();
+    const queue = new InMemoryQueue();
+    const clock = new InMemoryClock();
+
+    const fA = makeFlowA();
+    const wfA = await nagi({ flows: [fA], store, queue, clock });
+    const runId = await wfA.start(fA, {});
+
+    const fB = makeFlowB();
+    const wfB = await nagi({ flows: [fB], store, queue, clock });
+    const worker = wfB.worker({
+      timerSweepIntervalMs: 0,
+      snapshotGonePolicy: () => {
+        throw new Error("broken policy");
+      },
+    });
+    await worker.runUntilEmpty();
+
+    // Message survived (delayed, not visible now) and the run is untouched —
+    // the fallback keeps redelivery bounded without inventing a disposition.
+    expect(await queue.dequeue({ count: 10 })).toHaveLength(0);
+    expect((await store.loadRunState(runId)).phase.tag).toBe("running");
+  });
+});

--- a/packages/core/src/tests/heartbeat.test.ts
+++ b/packages/core/src/tests/heartbeat.test.ts
@@ -33,6 +33,7 @@ describe("startHeartbeat", () => {
         receipt: "42",
         intervalMs: 100,
         leaseMs: 500,
+        holdWarnMs: 0,
         emitLog,
       });
 
@@ -45,6 +46,56 @@ describe("startHeartbeat", () => {
       hb.stop();
       await vi.advanceTimersByTimeAsync(500);
       expect(extend).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("warns on each holdWarnMs crossing while a step holds its slot (lease-hold watchdog)", async () => {
+    vi.useFakeTimers();
+    try {
+      const queue = {
+        extend: vi.fn().mockResolvedValue(undefined),
+      } as unknown as Queue;
+      const { store } = makeStore();
+      const emitLog = vi.fn();
+
+      const hb = startHeartbeat({
+        queue,
+        store,
+        runId: "r" as RunId,
+        stepId: "s",
+        attempt: 1,
+        receipt: "42",
+        intervalMs: 100,
+        leaseMs: 500,
+        holdWarnMs: 250,
+        emitLog,
+      });
+
+      const holdWarns = () =>
+        emitLog.mock.calls.filter(([e]) =>
+          String(e.msg).includes("holding a worker slot"),
+        );
+
+      // Below the threshold: beats happen, no watchdog warning.
+      await vi.advanceTimersByTimeAsync(200);
+      expect(holdWarns()).toHaveLength(0);
+
+      // First crossing (>=250ms held) warns once — not once per beat.
+      await vi.advanceTimersByTimeAsync(200);
+      expect(holdWarns()).toHaveLength(1);
+      expect(holdWarns()[0]?.[0]?.attrs).toMatchObject({
+        runId: "r",
+        stepId: "s",
+        attempt: 1,
+      });
+
+      // Second crossing (>=500ms) warns again.
+      await vi.advanceTimersByTimeAsync(200);
+      expect(holdWarns()).toHaveLength(2);
+
+      hb.stop();
     } finally {
       vi.useRealTimers();
     }
@@ -70,6 +121,7 @@ describe("startHeartbeat", () => {
         receipt: "7",
         intervalMs: 50,
         leaseMs: 200,
+        holdWarnMs: 0,
         emitLog,
       });
 
@@ -106,6 +158,7 @@ describe("startHeartbeat", () => {
         receipt: "9",
         intervalMs: 50,
         leaseMs: 200,
+        holdWarnMs: 0,
         emitLog,
       });
 

--- a/packages/core/src/tests/inspect-queue.test.ts
+++ b/packages/core/src/tests/inspect-queue.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { flow } from "../builder";
+import { NagiRuntimeError } from "../errors";
+import { InMemoryClock, InMemoryQueue, InMemoryStore } from "../memory";
+import { nagi } from "../runtime";
+import type { Queue } from "../types";
+import { passthroughSchema } from "./test-helpers";
+
+function simpleFlow() {
+  return flow({
+    id: "inspectable",
+    input: passthroughSchema<Record<string, never>>(),
+    build: (b) => ({
+      s: b.task({ run: async () => ({ ok: true }) }),
+    }),
+  });
+}
+
+describe("wf.inspectQueue", () => {
+  it("shows a never-scheduled run's pending message, then empties once dispatched", async () => {
+    const store = new InMemoryStore();
+    const queue = new InMemoryQueue();
+    const clock = new InMemoryClock();
+    const f = simpleFlow();
+    const wf = await nagi({ flows: [f], store, queue, clock });
+
+    // No worker yet: the initial step's message sits undelivered — the
+    // "starved, never scheduled" triage shape.
+    const runId = await wf.start(f, {});
+    const before = await wf.inspectQueue(runId);
+    expect(before).toHaveLength(1);
+    expect(before[0]).toMatchObject({ stepId: "s", attempt: 1, readCount: 0 });
+
+    await wf.worker({ timerSweepIntervalMs: 0 }).runUntilEmpty();
+    expect(await wf.inspectQueue(runId)).toHaveLength(0);
+  });
+
+  it("throws NagiRuntimeError when the adapter has no inspect()", async () => {
+    const store = new InMemoryStore();
+    const inner = new InMemoryQueue();
+    // Shape-compatible adapter without the optional inspect capability.
+    const queue: Queue = {
+      enqueue: inner.enqueue.bind(inner),
+      dequeue: inner.dequeue.bind(inner),
+      ack: inner.ack.bind(inner),
+      nack: inner.nack.bind(inner),
+      extend: inner.extend.bind(inner),
+    };
+    const clock = new InMemoryClock();
+    const f = simpleFlow();
+    const wf = await nagi({ flows: [f], store, queue, clock });
+    const runId = await wf.start(f, {});
+    await expect(wf.inspectQueue(runId)).rejects.toThrowError(NagiRuntimeError);
+  });
+});

--- a/packages/core/src/tests/lease-reaper.test.ts
+++ b/packages/core/src/tests/lease-reaper.test.ts
@@ -254,6 +254,7 @@ describe("Heartbeat extends both queue VT and store lease", () => {
         receipt: "rcpt",
         intervalMs: 25,
         leaseMs: 100,
+        holdWarnMs: 0,
         emitLog,
       });
       await vi.advanceTimersByTimeAsync(80);

--- a/packages/core/src/tests/non-retryable-error.test.ts
+++ b/packages/core/src/tests/non-retryable-error.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { flow } from "../builder";
+import { NagiNonRetryableError } from "../errors";
+import { InMemoryClock, InMemoryQueue, InMemoryStore } from "../memory";
+import { nagi } from "../runtime";
+import { passthroughSchema } from "./test-helpers";
+
+const RETRY = { maxAttempts: 3, backoff: "fixed", initialDelayMs: 0 } as const;
+
+function harness() {
+  return {
+    store: new InMemoryStore(),
+    queue: new InMemoryQueue(),
+    clock: new InMemoryClock(),
+  };
+}
+
+describe("NagiNonRetryableError", () => {
+  it("fails the step on the first attempt, skipping the remaining retry budget", async () => {
+    const { store, queue, clock } = harness();
+    let attempts = 0;
+    const f = flow({
+      id: "nonretryable",
+      input: passthroughSchema<Record<string, never>>(),
+      build: (b) => ({
+        s: b.task({
+          retry: RETRY,
+          run: async () => {
+            attempts++;
+            throw new NagiNonRetryableError("orphaned input — no owning row");
+          },
+        }),
+      }),
+    });
+    const wf = await nagi({ flows: [f], store, queue, clock });
+    const runId = await wf.start(f, {});
+    await wf.worker({ timerSweepIntervalMs: 0 }).runUntilEmpty();
+
+    expect(attempts).toBe(1);
+    const state = await store.loadRunState(runId);
+    expect(state.phase.tag).toBe("failed");
+    if (state.phase.tag === "failed") {
+      expect(state.phase.error.name).toBe("NagiNonRetryableError");
+    }
+  });
+
+  it("is honored anywhere on the cause chain (survives SDK wrapping)", async () => {
+    const { store, queue, clock } = harness();
+    let attempts = 0;
+    const f = flow({
+      id: "nonretryable-wrapped",
+      input: passthroughSchema<Record<string, never>>(),
+      build: (b) => ({
+        s: b.task({
+          retry: RETRY,
+          run: async () => {
+            attempts++;
+            throw new Error("sdk wrapper", {
+              cause: new NagiNonRetryableError("permanently unprocessable"),
+            });
+          },
+        }),
+      }),
+    });
+    const wf = await nagi({ flows: [f], store, queue, clock });
+    const runId = await wf.start(f, {});
+    await wf.worker({ timerSweepIntervalMs: 0 }).runUntilEmpty();
+
+    expect(attempts).toBe(1);
+    expect((await store.loadRunState(runId)).phase.tag).toBe("failed");
+  });
+
+  it("control: a plain error still consumes the full retry budget", async () => {
+    const { store, queue, clock } = harness();
+    let attempts = 0;
+    const f = flow({
+      id: "retryable-control",
+      input: passthroughSchema<Record<string, never>>(),
+      build: (b) => ({
+        s: b.task({
+          retry: RETRY,
+          run: async () => {
+            attempts++;
+            throw new Error("transient");
+          },
+        }),
+      }),
+    });
+    const wf = await nagi({ flows: [f], store, queue, clock });
+    const runId = await wf.start(f, {});
+    await wf.worker({ timerSweepIntervalMs: 0 }).runUntilEmpty();
+
+    expect(attempts).toBe(3);
+    expect((await store.loadRunState(runId)).phase.tag).toBe("failed");
+  });
+});

--- a/packages/core/src/tests/onLog.test.ts
+++ b/packages/core/src/tests/onLog.test.ts
@@ -107,7 +107,10 @@ describe("onLog — record shape & level routing", () => {
       id: "sig-resolved",
       input: passthroughSchema<Record<string, never>>(),
       build: (b) => ({
-        wait: b.signal({ schema: passthroughSchema<{ ok: boolean }>() }),
+        wait: b.signal({
+          timeoutMs: "unbounded" as const,
+          schema: passthroughSchema<{ ok: boolean }>(),
+        }),
       }),
     });
     const h = await makeHarness(f, { onLog });
@@ -168,7 +171,10 @@ describe("onLog — record shape & level routing", () => {
       id: "wake-child",
       input: passthroughSchema<Record<string, never>>(),
       build: (b) => ({
-        gate: b.signal({ schema: passthroughSchema<{ ok: boolean }>() }),
+        gate: b.signal({
+          timeoutMs: "unbounded" as const,
+          schema: passthroughSchema<{ ok: boolean }>(),
+        }),
       }),
       output: (steps) => steps.gate,
     });
@@ -213,7 +219,10 @@ describe("onLog — record shape & level routing", () => {
       id: "wake2-child",
       input: passthroughSchema<Record<string, never>>(),
       build: (b) => ({
-        gate: b.signal({ schema: passthroughSchema<{ ok: boolean }>() }),
+        gate: b.signal({
+          timeoutMs: "unbounded" as const,
+          schema: passthroughSchema<{ ok: boolean }>(),
+        }),
       }),
       output: (steps) => steps.gate,
     });
@@ -222,7 +231,10 @@ describe("onLog — record shape & level routing", () => {
       input: passthroughSchema<Record<string, never>>(),
       build: (b) => ({
         sub: b.subflow(child, { input: () => ({}) }),
-        keepalive: b.signal({ schema: passthroughSchema<{ done: boolean }>() }),
+        keepalive: b.signal({
+          timeoutMs: "unbounded" as const,
+          schema: passthroughSchema<{ done: boolean }>(),
+        }),
       }),
     });
     const h = await makeHarness([parent, child], { onLog });

--- a/packages/core/src/tests/onLog.test.ts
+++ b/packages/core/src/tests/onLog.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { flow } from "../builder";
-import { InMemoryQueue, InMemoryStore } from "../memory";
+import { InMemoryClock, InMemoryQueue, InMemoryStore } from "../memory";
 import { nagi } from "../runtime";
 import { stepStateOf, stepStatusOf } from "../state";
 import type { LogEntry, QueueDequeueOpts, QueueMessage, RunId } from "../types";
@@ -11,6 +11,16 @@ class CrashingQueue extends InMemoryQueue {
     _opts: QueueDequeueOpts,
   ): Promise<readonly QueueMessage[]> {
     throw new Error("queue connection lost");
+  }
+}
+
+// The worker absorbs queue failures now, so exercising the loop-crash log
+// takes a broken Clock — the one adapter call still outside a guard.
+class CrashingClock extends InMemoryClock {
+  armed = false;
+  override now(): Date {
+    if (this.armed) throw new Error("clock read failed");
+    return super.now();
   }
 }
 
@@ -41,6 +51,29 @@ describe("onLog — record shape & level routing", () => {
 
   it("worker-exited-unexpectedly: exactly one error entry with the exact msg", async () => {
     const { onLog, entries } = spyOnLog();
+    const clock = new CrashingClock();
+    const handle = await nagi.run({
+      flows: [echo],
+      store: new InMemoryStore(),
+      queue: new InMemoryQueue(),
+      clock,
+      worker: { pollIntervalMs: 5 },
+      onLog,
+    });
+    clock.armed = true;
+    await vi.waitFor(() =>
+      expect(entries.filter((e) => e.level === "error")).toHaveLength(1),
+    );
+    const crash = entries.find((e) => e.level === "error") as LogEntry;
+    expect(crash.msg).toBe("nagi.run: worker exited unexpectedly");
+    expect(crash.attrs).toMatchObject({
+      error: expect.stringContaining("clock read failed"),
+    });
+    await handle.stop();
+  });
+
+  it("worker.dequeue-failed: a queue outage logs backoff, never a loop exit", async () => {
+    const { onLog, entries } = spyOnLog();
     const handle = await nagi.run({
       flows: [echo],
       store: new InMemoryStore(),
@@ -49,13 +82,21 @@ describe("onLog — record shape & level routing", () => {
       onLog,
     });
     await vi.waitFor(() =>
-      expect(entries.filter((e) => e.level === "error")).toHaveLength(1),
+      expect(
+        entries.filter((e) => e.msg === "worker.dequeue failed; backing off"),
+      ).not.toHaveLength(0),
     );
-    const crash = entries.find((e) => e.level === "error") as LogEntry;
-    expect(crash.msg).toBe("nagi.run: worker exited unexpectedly");
-    expect(crash.attrs).toMatchObject({
+    const entry = entries.find(
+      (e) => e.msg === "worker.dequeue failed; backing off",
+    ) as LogEntry;
+    expect(entry.level).toBe("error");
+    expect(entry.attrs).toMatchObject({
       error: expect.stringContaining("queue connection lost"),
+      consecutiveFailures: 1,
     });
+    expect(
+      entries.filter((e) => e.msg === "nagi.run: worker exited unexpectedly"),
+    ).toHaveLength(0);
     await handle.stop();
   });
 
@@ -527,13 +568,16 @@ describe("onLog — exactly-once & ordering", () => {
 
   it("a worker crash yields exactly one error entry", async () => {
     const { onLog, entries } = spyOnLog();
+    const clock = new CrashingClock();
     const handle = await nagi.run({
       flows: [echo],
       store: new InMemoryStore(),
-      queue: new CrashingQueue(),
+      queue: new InMemoryQueue(),
+      clock,
       worker: { pollIntervalMs: 5 },
       onLog,
     });
+    clock.armed = true;
     await vi.waitFor(() =>
       expect(entries.filter((e) => e.level === "error")).toHaveLength(1),
     );

--- a/packages/core/src/tests/operator.test.ts
+++ b/packages/core/src/tests/operator.test.ts
@@ -17,6 +17,7 @@ describe("wf.operator().skip()", () => {
       input: passthroughSchema<Record<string, never>>(),
       build: (b) => {
         const a = b.signal({
+          timeoutMs: "unbounded" as const,
           schema: passthroughSchema<Record<string, never>>(),
         });
         const bStep = b.task({
@@ -58,6 +59,7 @@ describe("wf.operator().skip()", () => {
       input: passthroughSchema<Record<string, never>>(),
       build: (b) => {
         const a = b.signal({
+          timeoutMs: "unbounded" as const,
           schema: passthroughSchema<{ v: number }>(),
         });
         const bStep = b.task({
@@ -88,7 +90,10 @@ describe("wf.operator().skip()", () => {
       id: "skip-no-actor",
       input: passthroughSchema<Record<string, never>>(),
       build: (b) => ({
-        a: b.signal({ schema: passthroughSchema<Record<string, never>>() }),
+        a: b.signal({
+          timeoutMs: "unbounded" as const,
+          schema: passthroughSchema<Record<string, never>>(),
+        }),
       }),
     });
     const h = await makeHarness(f);
@@ -105,7 +110,10 @@ describe("wf.operator().skip()", () => {
       id: "skip-unknown-step",
       input: passthroughSchema<Record<string, never>>(),
       build: (b) => ({
-        a: b.signal({ schema: passthroughSchema<Record<string, never>>() }),
+        a: b.signal({
+          timeoutMs: "unbounded" as const,
+          schema: passthroughSchema<Record<string, never>>(),
+        }),
       }),
     });
     const h = await makeHarness(f);
@@ -233,7 +241,10 @@ describe("wf.operator().retry()", () => {
       id: "retry-canceled-run",
       input: passthroughSchema<Record<string, never>>(),
       build: (b) => ({
-        a: b.signal({ schema: passthroughSchema<Record<string, never>>() }),
+        a: b.signal({
+          timeoutMs: "unbounded" as const,
+          schema: passthroughSchema<Record<string, never>>(),
+        }),
       }),
     });
     const h = await makeHarness(f);
@@ -252,7 +263,10 @@ describe("wf.operator().abort()", () => {
       id: "abort-audit",
       input: passthroughSchema<Record<string, never>>(),
       build: (b) => ({
-        a: b.signal({ schema: passthroughSchema<Record<string, never>>() }),
+        a: b.signal({
+          timeoutMs: "unbounded" as const,
+          schema: passthroughSchema<Record<string, never>>(),
+        }),
       }),
     });
     const h = await makeHarness(f);
@@ -294,7 +308,10 @@ describe("wf.operator().abort()", () => {
       id: "cancel-explicit",
       input: passthroughSchema<Record<string, never>>(),
       build: (b) => ({
-        a: b.signal({ schema: passthroughSchema<Record<string, never>>() }),
+        a: b.signal({
+          timeoutMs: "unbounded" as const,
+          schema: passthroughSchema<Record<string, never>>(),
+        }),
       }),
     });
     const h = await makeHarness(f);

--- a/packages/core/src/tests/per-flow-concurrency.test.ts
+++ b/packages/core/src/tests/per-flow-concurrency.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { flow } from "../builder";
+import { InMemoryClock, InMemoryQueue, InMemoryStore } from "../memory";
+import { nagi } from "../runtime";
+import type { RunId } from "../types";
+import { passthroughSchema } from "./test-helpers";
+
+// The outage shape this bounds: N steps of ONE flow wedge in their handlers
+// and hold every worker slot, so no other flow's runs ever get scheduled.
+// With maxConcurrencyPerFlow, the wedged flow saturates its cap and the
+// remaining slots keep serving everyone else.
+describe("worker maxConcurrencyPerFlow", () => {
+  it("a slot-hogging flow cannot starve another flow", async () => {
+    const store = new InMemoryStore();
+    const queue = new InMemoryQueue();
+    const clock = new InMemoryClock();
+
+    let concurrentHogs = 0;
+    let maxConcurrentHogs = 0;
+    let releaseHogs: () => void = () => {};
+    const hogGate = new Promise<void>((resolve) => {
+      releaseHogs = resolve;
+    });
+
+    const hog = flow({
+      id: "hog",
+      input: passthroughSchema<Record<string, never>>(),
+      build: (b) => ({
+        wedge: b.task({
+          run: async () => {
+            concurrentHogs++;
+            maxConcurrentHogs = Math.max(maxConcurrentHogs, concurrentHogs);
+            await hogGate;
+            concurrentHogs--;
+            return null;
+          },
+        }),
+      }),
+    });
+    const bystander = flow({
+      id: "bystander",
+      input: passthroughSchema<Record<string, never>>(),
+      build: (b) => ({
+        s: b.task({ run: async () => ({ ok: true }) }),
+      }),
+    });
+
+    const wf = await nagi({ flows: [hog, bystander], store, queue, clock });
+
+    // 4 hog runs first, so they reach the front of the queue, then 1 bystander.
+    const hogRuns: RunId[] = [];
+    for (let i = 0; i < 4; i++) hogRuns.push(await wf.start(hog, {}));
+    const bystanderRun = await wf.start(bystander, {});
+
+    const ac = new AbortController();
+    const worker = wf.worker({
+      concurrency: 4,
+      maxConcurrencyPerFlow: 3,
+      pollIntervalMs: 5,
+      timerSweepIntervalMs: 0,
+      signal: ac.signal,
+    });
+    const loop = worker.run();
+
+    // The bystander completes WHILE the hogs are still wedged — the cap held
+    // a slot open for it.
+    try {
+      const deadline = Date.now() + 5_000;
+      for (;;) {
+        const s = await store.loadRunState(bystanderRun);
+        if (s.phase.tag === "completed") break;
+        if (Date.now() > deadline)
+          throw new Error("bystander starved: cap did not hold a slot open");
+        await new Promise((r) => setTimeout(r, 10));
+      }
+      expect(maxConcurrentHogs).toBeLessThanOrEqual(3);
+    } finally {
+      releaseHogs();
+      ac.abort();
+      await loop;
+    }
+
+    // Once released, the wedged flow itself still drains to completion —
+    // deferral delays, it never drops.
+    await wf.worker({ timerSweepIntervalMs: 0 }).runUntilEmpty();
+    for (const runId of hogRuns) {
+      expect((await store.loadRunState(runId)).phase.tag).toBe("completed");
+    }
+  });
+
+  it("messages without flowId are exempt (pre-upgrade messages still dispatch)", async () => {
+    const store = new InMemoryStore();
+    const queue = new InMemoryQueue();
+    const clock = new InMemoryClock();
+
+    const f = flow({
+      id: "legacy",
+      input: passthroughSchema<Record<string, never>>(),
+      build: (b) => ({
+        s: b.task({ run: async () => ({ ok: true }) }),
+      }),
+    });
+    const wf = await nagi({ flows: [f], store, queue, clock });
+    const runId = await wf.start(f, {});
+
+    // Strip flowId from the queued message, simulating a pre-upgrade envelope.
+    const pending = (
+      queue as unknown as { pending: Array<Record<string, unknown>> }
+    ).pending;
+    for (const item of pending) delete item["flowId"];
+
+    await wf
+      .worker({ maxConcurrencyPerFlow: 1, timerSweepIntervalMs: 0 })
+      .runUntilEmpty();
+    expect((await store.loadRunState(runId)).phase.tag).toBe("completed");
+  });
+});

--- a/packages/core/src/tests/replay-from.test.ts
+++ b/packages/core/src/tests/replay-from.test.ts
@@ -77,7 +77,10 @@ describe("wf.replay({ from }) — step-scoped replay", () => {
       id: "from-running",
       input: passthroughSchema<Record<string, never>>(),
       build: (b) => ({
-        wait: b.signal({ schema: passthroughSchema<Record<string, never>>() }),
+        wait: b.signal({
+          timeoutMs: "unbounded" as const,
+          schema: passthroughSchema<Record<string, never>>(),
+        }),
       }),
     });
     const h = await makeHarness(f);

--- a/packages/core/src/tests/runtime-run.test.ts
+++ b/packages/core/src/tests/runtime-run.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { flow } from "../builder";
-import { InMemoryQueue, InMemoryStore } from "../memory";
+import { InMemoryClock, InMemoryQueue, InMemoryStore } from "../memory";
 import { nagi } from "../runtime";
 import type { LogEntry, QueueDequeueOpts, QueueMessage } from "../types";
 import { passthroughSchema } from "./test-helpers";
@@ -31,6 +31,16 @@ class CrashingQueue extends InMemoryQueue {
     _opts: QueueDequeueOpts,
   ): Promise<readonly QueueMessage[]> {
     throw new Error("queue connection lost");
+  }
+}
+
+// A queue failure no longer reaches nagi.run — the worker absorbs it. Crashing
+// the loop now takes a broken Clock, the one adapter call left outside a guard.
+class CrashingClock extends InMemoryClock {
+  armed = false;
+  override now(): Date {
+    if (this.armed) throw new Error("clock read failed");
+    return super.now();
   }
 }
 
@@ -143,6 +153,27 @@ describe("nagi.run — graceful vs crash", () => {
 
   it("a true loop crash emits exactly one error entry; stop() still resolves", async () => {
     const { onLog, errors } = captureOnLog();
+    const clock = new CrashingClock();
+    const handle = await nagi.run({
+      flows: [echo],
+      store: new InMemoryStore(),
+      queue: new InMemoryQueue(),
+      clock,
+      worker: { pollIntervalMs: 5 },
+      onLog,
+    });
+    clock.armed = true;
+    await vi.waitFor(() => expect(errors()).toHaveLength(1));
+    const crash = errors()[0];
+    expect(crash?.msg).toBe("nagi.run: worker exited unexpectedly");
+    expect(crash?.attrs).toMatchObject({
+      error: expect.stringContaining("clock read failed"),
+    });
+    await expect(handle.stop()).resolves.toBeUndefined();
+  });
+
+  it("a crashing queue does NOT exit the loop — it backs off and retries", async () => {
+    const { onLog, errors } = captureOnLog();
     const handle = await nagi.run({
       flows: [echo],
       store: new InMemoryStore(),
@@ -150,12 +181,14 @@ describe("nagi.run — graceful vs crash", () => {
       worker: { pollIntervalMs: 5 },
       onLog,
     });
-    await vi.waitFor(() => expect(errors()).toHaveLength(1));
-    const crash = errors()[0];
-    expect(crash?.msg).toBe("nagi.run: worker exited unexpectedly");
-    expect(crash?.attrs).toMatchObject({
-      error: expect.stringContaining("queue connection lost"),
-    });
+    await vi.waitFor(() =>
+      expect(
+        errors().filter((e) => e.msg === "worker.dequeue failed; backing off"),
+      ).not.toHaveLength(0),
+    );
+    expect(
+      errors().filter((e) => e.msg === "nagi.run: worker exited unexpectedly"),
+    ).toHaveLength(0);
     await expect(handle.stop()).resolves.toBeUndefined();
   });
 });

--- a/packages/core/src/tests/runtime.test.ts
+++ b/packages/core/src/tests/runtime.test.ts
@@ -125,6 +125,7 @@ describe("e2e: signal full loop", () => {
           run: async ({ input }) => ({ subject: input.subject }),
         });
         const review = b.signal({
+          timeoutMs: "unbounded" as const,
           needs: { prep },
           schema: passthroughSchema<{ approved: boolean }>(),
         });

--- a/packages/core/src/tests/signal-multi-name.test.ts
+++ b/packages/core/src/tests/signal-multi-name.test.ts
@@ -12,6 +12,7 @@ describe("b.signal — single-name back-compat", () => {
       input: passthroughSchema<Record<string, never>>(),
       build: (b) => ({
         review: b.signal({
+          timeoutMs: "unbounded" as const,
           schema: passthroughSchema<{ ok: boolean }>(),
         }),
       }),
@@ -40,6 +41,7 @@ describe("b.signal — single-name back-compat", () => {
       input: passthroughSchema<Record<string, never>>(),
       build: (b) => ({
         review: b.signal({
+          timeoutMs: "unbounded" as const,
           names: ["approval"],
           schema: passthroughSchema<{ ok: boolean }>(),
         }),
@@ -67,6 +69,7 @@ describe("b.signal — single-name back-compat", () => {
       input: passthroughSchema<Record<string, never>>(),
       build: (b) => ({
         review: b.signal({
+          timeoutMs: "unbounded" as const,
           names: ["approval"],
           schema: passthroughSchema<{ ok: boolean }>(),
         }),
@@ -94,6 +97,7 @@ describe("b.signal — multi-name", () => {
       input: passthroughSchema<Record<string, never>>(),
       build: (b) => ({
         transcript: b.signal({
+          timeoutMs: "unbounded" as const,
           names: ["audioReady", "recordingReady"],
           schema: passthroughSchema<
             { audioUrl: string } | { transcript: string }
@@ -200,10 +204,12 @@ describe("b.signal — construction-time uniqueness", () => {
         input: passthroughSchema<Record<string, never>>(),
         build: (b) => ({
           transcript: b.signal({
+            timeoutMs: "unbounded" as const,
             names: ["x"],
             schema: passthroughSchema<{ v: number }>(),
           }),
           x: b.signal({
+            timeoutMs: "unbounded" as const,
             schema: passthroughSchema<{ v: number }>(),
           }),
         }),
@@ -218,10 +224,12 @@ describe("b.signal — construction-time uniqueness", () => {
         input: passthroughSchema<Record<string, never>>(),
         build: (b) => ({
           a: b.signal({
+            timeoutMs: "unbounded" as const,
             names: ["shared", "onlyA"],
             schema: passthroughSchema<{ v: number }>(),
           }),
           b: b.signal({
+            timeoutMs: "unbounded" as const,
             names: ["shared", "onlyB"],
             schema: passthroughSchema<{ v: number }>(),
           }),
@@ -237,6 +245,7 @@ describe("b.signal — construction-time uniqueness", () => {
         input: passthroughSchema<Record<string, never>>(),
         build: (b) => ({
           ping: b.signal({
+            timeoutMs: "unbounded" as const,
             names: ["ping", "PING"],
             schema: passthroughSchema<{ v: number }>(),
           }),
@@ -255,10 +264,12 @@ describe("b.signal — canonical hash invariants", () => {
         only: b.signal(
           names !== undefined
             ? {
+                timeoutMs: "unbounded" as const,
                 names: names as readonly [string, ...string[]],
                 schema: passthroughSchema<{ v: number }>(),
               }
             : {
+                timeoutMs: "unbounded" as const,
                 schema: passthroughSchema<{ v: number }>(),
               },
         ),
@@ -305,7 +316,10 @@ describe("b.signal — canonical hash invariants", () => {
       id: "hash-target",
       input: passthroughSchema<Record<string, never>>(),
       build: (b) => ({
-        x: b.signal({ schema: passthroughSchema<{ v: number }>() }),
+        x: b.signal({
+          timeoutMs: "unbounded" as const,
+          schema: passthroughSchema<{ v: number }>(),
+        }),
       }),
     });
     const stepYAliasedToX = flow({
@@ -313,6 +327,7 @@ describe("b.signal — canonical hash invariants", () => {
       input: passthroughSchema<Record<string, never>>(),
       build: (b) => ({
         y: b.signal({
+          timeoutMs: "unbounded" as const,
           names: ["x"],
           schema: passthroughSchema<{ v: number }>(),
         }),
@@ -331,6 +346,7 @@ describe("b.signal — type-level constraints", () => {
       input: passthroughSchema<Record<string, never>>(),
       build: (b) => ({
         bad: b.signal({
+          timeoutMs: "unbounded" as const,
           // @ts-expect-error
           names: [],
           schema: passthroughSchema<{ v: number }>(),

--- a/packages/core/src/tests/signal-timeout.test.ts
+++ b/packages/core/src/tests/signal-timeout.test.ts
@@ -12,6 +12,7 @@ function gatedFlow(opts: { id: string; timeoutMs?: number }) {
     input: emptySchema(),
     build: (b) => {
       const awaitAudio = b.signal({
+        timeoutMs: "unbounded" as const,
         names: ["audioReady", "recordingReady"],
         schema: passthroughSchema<{ ok: boolean }>(),
         ...(opts.timeoutMs != null ? { timeoutMs: opts.timeoutMs } : {}),

--- a/packages/core/src/tests/subflow-reap-supersede.test.ts
+++ b/packages/core/src/tests/subflow-reap-supersede.test.ts
@@ -21,7 +21,10 @@ describe("b.subflow — lease-reap does not self-supersede (prod-faithful)", () 
       // cancel the first — the prod child concurrency config.
       concurrency: { keyFn: () => "fixed", mode: "cancel-in-progress" },
       build: (b) => ({
-        wait: b.signal({ schema: passthroughSchema<{ ok: true }>() }),
+        wait: b.signal({
+          timeoutMs: "unbounded" as const,
+          schema: passthroughSchema<{ ok: true }>(),
+        }),
       }),
       output: (steps) => steps.wait,
     });
@@ -64,7 +67,10 @@ describe("b.subflow — lease-reap does not self-supersede (prod-faithful)", () 
       id: "child-parker",
       input: passthroughSchema<{ x: number }>(),
       build: (b) => ({
-        wait: b.signal({ schema: passthroughSchema<{ y: number }>() }),
+        wait: b.signal({
+          timeoutMs: "unbounded" as const,
+          schema: passthroughSchema<{ y: number }>(),
+        }),
       }),
       output: (steps) => steps.wait,
     });

--- a/packages/core/src/tests/subflow.test.ts
+++ b/packages/core/src/tests/subflow.test.ts
@@ -234,7 +234,10 @@ describe("b.subflow — cancel cascade", () => {
       id: "gc-parked",
       input: passthroughSchema<Record<string, never>>(),
       build: (b) => ({
-        wait: b.signal({ schema: passthroughSchema<{ ok: true }>() }),
+        wait: b.signal({
+          timeoutMs: "unbounded" as const,
+          schema: passthroughSchema<{ ok: true }>(),
+        }),
       }),
       output: (steps) => steps.wait,
     });
@@ -284,7 +287,10 @@ describe("b.subflow — cancel cascade", () => {
       id: "c-canceled-from-outside",
       input: passthroughSchema<Record<string, never>>(),
       build: (b) => ({
-        wait: b.signal({ schema: passthroughSchema<{ ok: true }>() }),
+        wait: b.signal({
+          timeoutMs: "unbounded" as const,
+          schema: passthroughSchema<{ ok: true }>(),
+        }),
       }),
       output: (steps) => steps.wait,
     });

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -804,6 +804,17 @@ export interface QueueEnqueueOpts {
   readonly flowId?: string;
 }
 
+// Read-only snapshot of one queued message, for operator triage: a message
+// with visibleAt in the future is leased/delayed; a high readCount is a
+// redelivery loop; no entries at all for a non-terminal run means the run is
+// waiting on a signal/child — or was never scheduled (worker starvation).
+export interface QueueInspectEntry {
+  readonly stepId: StepId;
+  readonly attempt: AttemptNumber;
+  readonly readCount: number;
+  readonly visibleAt: Date;
+}
+
 export interface Queue {
   enqueue(runId: RunId, stepId: StepId, opts?: QueueEnqueueOpts): Promise<void>;
   dequeue(opts: QueueDequeueOpts): Promise<readonly QueueMessage[]>;
@@ -813,6 +824,9 @@ export interface Queue {
   // Optional one-shot, idempotent schema provisioning. nagi() awaits it once at
   // construction (fail-fast). Adapters needing none omit it.
   ensureSchema?(): Promise<void>;
+  // Optional read-only triage view of a run's in-queue messages (see
+  // wf.inspectQueue). Optional because not every broker can query by run.
+  inspect?(runId: RunId): Promise<readonly QueueInspectEntry[]>;
 }
 
 export interface Clock {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -502,7 +502,12 @@ export interface WorkerRunResult {
 }
 
 export interface Worker {
+  // Settles ONLY when the configured abort signal fires. Queue and dispatch
+  // failures are logged and retried with backoff, never rethrown: a rejection
+  // here would stop all flow processing in a process that still looks healthy.
   run(): Promise<void>;
+  // Bounded drains, for tests and request/cron-scoped processing. These DO
+  // reject on queue failure — the caller is awaiting a result and can react.
   runOnce(opts?: WorkerRunOnceOpts): Promise<WorkerRunResult>;
   runUntilEmpty(opts?: WorkerRunUntilEmptyOpts): Promise<WorkerRunResult>;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -155,13 +155,16 @@ export interface RetryPolicy {
   readonly retryOn?: (error: unknown) => boolean;
 }
 
+// No timeoutMs here: it was only ever ENFORCED for signal steps, and an
+// unenforced timeout knob on tasks was false safety. Signal steps carry a
+// required timeout (SignalConfig); handler-step deadline enforcement is
+// tracked upstream as its own feature.
 interface StepConfigBase<Input, N extends NeedsMap> {
   readonly needs?: N;
   readonly when?: (args: {
     readonly input: NoInfer<Input>;
     readonly needs: NoInfer<ResolvedNeeds<N>>;
   }) => boolean;
-  readonly timeoutMs?: Millis;
 }
 
 export interface StepLifecycleHooks<Output> {
@@ -213,6 +216,14 @@ export interface SignalConfig<
 > extends StepConfigBase<Input, N> {
   readonly schema: Schema;
   readonly names?: readonly [string, ...string[]];
+  // REQUIRED: every wait must state its deadline. A number arms a timer that
+  // fails the step as NagiSignalTimeoutError when no signal arrives in time;
+  // "unbounded" is an explicit opt-in to parking forever. There is no default
+  // on purpose — timeout-less waits have caused multi-day production outages
+  // (a parked step whose signal never comes is invisible until something
+  // else pages), so unbounded parking must be a written decision, not an
+  // omission.
+  readonly timeoutMs: Millis | "unbounded";
 }
 
 export interface MatchArmGuard<Input, N extends NeedsMap, M extends StepMap> {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -473,6 +473,14 @@ export interface WorkerConfig {
   // not-yet-updated worker to claim during a rolling deploy; "fail"
   // terminally fails the run with the snapshot-gone error and acks.
   readonly snapshotGonePolicy?: SnapshotGonePolicy;
+  // Cap on worker slots any single flow may occupy at once. Bounds blast
+  // radius: without it, one wedged flow's steps can hold every slot and
+  // starve all other flows (an observed multi-day outage shape). Over-cap
+  // messages are deferred with a delayed nack, not dropped. Unset = no cap
+  // (correct for single-flow deployments, where a cap only wastes slots);
+  // multi-flow deployments should set it to at most concurrency - 1 so one
+  // flow can never occupy the whole pool.
+  readonly maxConcurrencyPerFlow?: number;
 }
 
 export type SnapshotGoneDisposition =
@@ -778,6 +786,11 @@ export interface QueueMessage {
   // Unlike `attempt` (stamped at enqueue), this counts every redelivery —
   // nacks, lease expiries — so it is the poison-message signal.
   readonly readCount: number;
+  // Flow that owns the run, stamped at enqueue. Drives the worker's per-flow
+  // concurrency cap. Optional ONLY for messages enqueued before the field
+  // existed (they must still dispatch after an upgrade) — absent means exempt
+  // from the cap, and every current enqueue path stamps it.
+  readonly flowId?: string;
 }
 
 export interface QueueDequeueOpts {
@@ -788,6 +801,7 @@ export interface QueueEnqueueOpts {
   readonly attempt?: AttemptNumber;
   readonly delayMs?: Millis;
   readonly payload?: Json;
+  readonly flowId?: string;
 }
 
 export interface Queue {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -456,7 +456,19 @@ export interface WorkerConfig {
   // (tests that drive the sweep explicitly). Checked by elapsed wall-clock each
   // loop iteration, so a fully-busy worker still sweeps on schedule.
   readonly timerSweepIntervalMs?: Millis;
+  // Decides retry-vs-fail for a message whose run's flow snapshot is gone
+  // (deploy replaced the flow while the run was in flight). Defaults to
+  // defaultSnapshotGonePolicy. "retry" keeps the message alive for a
+  // not-yet-updated worker to claim during a rolling deploy; "fail"
+  // terminally fails the run with the snapshot-gone error and acks.
+  readonly snapshotGonePolicy?: SnapshotGonePolicy;
 }
+
+export type SnapshotGoneDisposition =
+  | { readonly action: "retry"; readonly delayMs: Millis }
+  | { readonly action: "fail" };
+
+export type SnapshotGonePolicy = (readCount: number) => SnapshotGoneDisposition;
 
 export interface WorkerRunOnceOpts {
   readonly maxSteps?: number;
@@ -751,6 +763,10 @@ export interface QueueMessage {
   readonly stepId: StepId;
   readonly payload: Json;
   readonly attempt: AttemptNumber;
+  // Deliveries of this message including the current one (pgmq read_ct).
+  // Unlike `attempt` (stamped at enqueue), this counts every redelivery —
+  // nacks, lease expiries — so it is the poison-message signal.
+  readonly readCount: number;
 }
 
 export interface QueueDequeueOpts {

--- a/packages/core/src/worker.ts
+++ b/packages/core/src/worker.ts
@@ -59,6 +59,8 @@ class WorkerImpl implements Worker {
   private readonly dispatcher: Dispatcher;
   private readonly timerSweepIntervalMs: Millis;
   private readonly snapshotGonePolicy: SnapshotGonePolicy;
+  private readonly maxPerFlow: number | undefined;
+  private readonly inFlightByFlow = new Map<string, number>();
   private lastTimerSweepAt: number;
 
   constructor(
@@ -71,11 +73,44 @@ class WorkerImpl implements Worker {
     this.dispatcher = makeDispatcher(deps);
     this.snapshotGonePolicy =
       config?.snapshotGonePolicy ?? defaultSnapshotGonePolicy;
+    this.maxPerFlow =
+      config?.maxConcurrencyPerFlow !== undefined
+        ? Math.max(1, config.maxConcurrencyPerFlow)
+        : undefined;
     this.timerSweepIntervalMs =
       config?.timerSweepIntervalMs ?? DEFAULT_TIMER_SWEEP_INTERVAL_MS;
     // Anchor the first sweep one interval out, like the lease-reaper sleeps
     // before its first pass — no sweep storm at boot.
     this.lastTimerSweepAt = this.deps.clock.now().getTime();
+  }
+
+  // Per-flow blast-radius bound (maxConcurrencyPerFlow). A message over its
+  // flow's cap is DEFERRED — delayed nack, redelivered after ~pollIntervalMs —
+  // not dropped. Messages without flowId (enqueued pre-upgrade) are exempt.
+  // Deferral does raise pgmq read_ct, which the snapshot-gone policy reads;
+  // that only matters if the same flow later goes snapshot-gone, where an
+  // earlier fail is acceptable.
+  private admitFlow(msg: QueueMessage): boolean {
+    if (this.maxPerFlow === undefined || msg.flowId === undefined) return true;
+    return (this.inFlightByFlow.get(msg.flowId) ?? 0) < this.maxPerFlow;
+  }
+
+  // Returns the release fn; caller must invoke it exactly once when done.
+  private trackFlow(msg: QueueMessage): () => void {
+    const { flowId } = msg;
+    if (flowId === undefined) return () => {};
+    this.inFlightByFlow.set(flowId, (this.inFlightByFlow.get(flowId) ?? 0) + 1);
+    return () => {
+      const n = (this.inFlightByFlow.get(flowId) ?? 1) - 1;
+      if (n <= 0) this.inFlightByFlow.delete(flowId);
+      else this.inFlightByFlow.set(flowId, n);
+    };
+  }
+
+  private async defer(msg: QueueMessage): Promise<void> {
+    try {
+      await this.deps.queue.nack(msg.receipt, { delayMs: this.pollIntervalMs });
+    } catch {}
   }
 
   async run(): Promise<void> {
@@ -96,7 +131,10 @@ class WorkerImpl implements Worker {
         continue;
       }
 
-      for (const msg of messages) this.fire(msg);
+      for (const msg of messages) {
+        if (this.admitFlow(msg)) this.fire(msg);
+        else await this.defer(msg);
+      }
     }
     await this.drain();
   }
@@ -128,8 +166,26 @@ class WorkerImpl implements Worker {
       const messages = await this.dequeue(opts.batchSize(processed));
       if (messages.length === 0) break;
 
-      await Promise.all(messages.map((m) => this.dispatchSafely(m)));
-      processed += messages.length;
+      const admitted: Array<{
+        readonly m: QueueMessage;
+        readonly release: () => void;
+      }> = [];
+      for (const m of messages) {
+        // Sequential admission: each admit sees the batch-mates already
+        // admitted, so a whole batch of one flow cannot leapfrog the cap.
+        if (this.admitFlow(m)) {
+          admitted.push({ m, release: this.trackFlow(m) });
+        } else {
+          await this.defer(m);
+        }
+      }
+      await Promise.all(
+        admitted.map(({ m }) => this.dispatchSafely(m)),
+      ).finally(() => {
+        for (const { release } of admitted) release();
+      });
+      processed += admitted.length;
+      if (admitted.length === 0) break;
     }
     return { processed };
   }
@@ -140,7 +196,9 @@ class WorkerImpl implements Worker {
 
   private fire(msg: QueueMessage): void {
     this.inFlight++;
+    const release = this.trackFlow(msg);
     void this.dispatchSafely(msg).finally(() => {
+      release();
       this.inFlight = Math.max(0, this.inFlight - 1);
     });
   }

--- a/packages/core/src/worker.ts
+++ b/packages/core/src/worker.ts
@@ -1,9 +1,11 @@
 import { type DispatchDeps, type Dispatcher, makeDispatcher } from "./dispatch";
-import { NagiFlowSnapshotGoneError } from "./errors";
+import { NagiFlowSnapshotGoneError, serializeError } from "./errors";
+import { Facts } from "./facts";
 import type {
   Clock,
   Millis,
   QueueMessage,
+  SnapshotGonePolicy,
   Worker,
   WorkerConfig,
   WorkerRunOnceOpts,
@@ -14,6 +16,32 @@ import type {
 const DEFAULT_CONCURRENCY = 4;
 const DEFAULT_POLL_INTERVAL_MS: Millis = 1_000;
 const DEFAULT_TIMER_SWEEP_INTERVAL_MS: Millis = 30_000;
+const SNAPSHOT_GONE_FALLBACK_NACK_DELAY_MS: Millis = 30_000;
+
+// Bounds redelivery of a message whose run is pinned to a flow snapshot no
+// longer in any live registry. "retry" exists ONLY for the rolling-deploy
+// window, where a not-yet-replaced worker may still hold the pinned code and
+// can finish the run. Once that window has clearly passed, retrying is pure
+// poison: the observed failure mode was set_vt(0) redelivery ~1/s for 8 days
+// (read_ct 660k) drowning staging logs. "fail" is the honest terminal state —
+// the run cannot advance on any current code — and unlike the old behavior it
+// leaves a workflow_run.error a human can triage, then admin-restart.
+// Quadratic backoff capped at 5 min, budget 60 deliveries ≈ a 4.2h retry
+// window. Rationale: the window must comfortably exceed the longest plausible
+// old/new worker overlap (a rolling deploy is minutes, but a wedged draining
+// task has been observed hanging on for hours), and 4h matches the house
+// signal-timeout constant while staying under typical stuck-run alerting
+// thresholds (6h) — so a run that is GOING to fail fails before it pages as
+// stuck. Within the window: fast redelivery early (sub-minute, when a frozen
+// worker most likely still exists), quiet later (5 min cadence, ~60 log lines
+// total for a run that never recovers — vs 660k at set_vt(0)).
+export const defaultSnapshotGonePolicy: SnapshotGonePolicy = (readCount) => {
+  if (readCount > 60) return { action: "fail" };
+  return {
+    action: "retry",
+    delayMs: Math.min(readCount * readCount * 1_000, 300_000),
+  };
+};
 
 export interface WorkerDeps extends DispatchDeps {
   readonly clock: Clock;
@@ -30,6 +58,7 @@ class WorkerImpl implements Worker {
   private readonly signal: AbortSignal | undefined;
   private readonly dispatcher: Dispatcher;
   private readonly timerSweepIntervalMs: Millis;
+  private readonly snapshotGonePolicy: SnapshotGonePolicy;
   private lastTimerSweepAt: number;
 
   constructor(
@@ -40,6 +69,8 @@ class WorkerImpl implements Worker {
     this.pollIntervalMs = config?.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
     this.signal = config?.signal;
     this.dispatcher = makeDispatcher(deps);
+    this.snapshotGonePolicy =
+      config?.snapshotGonePolicy ?? defaultSnapshotGonePolicy;
     this.timerSweepIntervalMs =
       config?.timerSweepIntervalMs ?? DEFAULT_TIMER_SWEEP_INTERVAL_MS;
     // Anchor the first sweep one interval out, like the lease-reaper sleeps
@@ -119,22 +150,23 @@ class WorkerImpl implements Worker {
       await this.dispatcher.dispatchMessage(msg);
     } catch (err) {
       if (err instanceof NagiFlowSnapshotGoneError) {
-        // Nack (do not emit step.failed) so a frozen-version worker can pick
-        // the message up. Logged at warn so consumer ops see the diagnostic
-        // hash pair and grep/restart against the pinned code.
-        this.deps.emitLog({
-          level: "warn",
-          msg: "worker.dispatch: flow snapshot gone — nacking",
-          attrs: {
-            runId: err.runId,
-            flowId: err.flowId,
-            pinnedHash: err.pinnedHash,
-            currentHash: err.currentHash,
-          },
-        });
         try {
-          await this.deps.queue.nack(msg.receipt);
-        } catch {}
+          await this.handleSnapshotGone(msg, err);
+        } catch (handleErr) {
+          // A broken policy or store failure must neither escape (fire() has
+          // no rejection handler) nor tight-loop the message — the delayed
+          // nack keeps the redelivery cadence bounded until it's fixed.
+          this.deps.emitLog({
+            level: "error",
+            msg: "worker.dispatch: snapshot-gone handling failed",
+            attrs: { runId: err.runId, error: String(handleErr) },
+          });
+          try {
+            await this.deps.queue.nack(msg.receipt, {
+              delayMs: SNAPSHOT_GONE_FALLBACK_NACK_DELAY_MS,
+            });
+          } catch {}
+        }
         return;
       }
       this.deps.emitLog({
@@ -146,6 +178,68 @@ class WorkerImpl implements Worker {
         await this.deps.queue.nack(msg.receipt);
       } catch {}
     }
+  }
+
+  // A snapshot-gone message is retried (nack, delayed) only while the policy
+  // says a frozen-version worker might still claim it; past that budget the
+  // run is terminally failed with the snapshot-gone error and the message
+  // acked, so poison messages cannot outlive the deploy that orphaned them.
+  // (Terminal runs never reach here — dispatchMessage acks them itself.)
+  private async handleSnapshotGone(
+    msg: QueueMessage,
+    err: NagiFlowSnapshotGoneError,
+  ): Promise<void> {
+    const attrs = {
+      runId: err.runId,
+      flowId: err.flowId,
+      pinnedHash: err.pinnedHash,
+      currentHash: err.currentHash,
+      readCount: msg.readCount,
+    };
+    const disposition = this.snapshotGonePolicy(msg.readCount);
+
+    if (disposition.action === "retry") {
+      // Do not emit step.failed: the step never ran. Logged at warn so
+      // consumer ops see the diagnostic hash pair while the deploy settles.
+      this.deps.emitLog({
+        level: "warn",
+        msg: "worker.dispatch: flow snapshot gone — nacking for a frozen-version worker",
+        attrs,
+      });
+      try {
+        await this.deps.queue.nack(msg.receipt, {
+          delayMs: disposition.delayMs,
+        });
+      } catch {}
+      return;
+    }
+
+    this.deps.emitLog({
+      level: "error",
+      msg: "worker.dispatch: flow snapshot gone — redelivery budget exhausted, failing run",
+      attrs,
+    });
+    const serialized = serializeError(err);
+    await this.deps.store.appendFact(
+      msg.runId,
+      Facts.flowFailed(msg.runId, serialized, this.deps.clock.now()),
+    );
+    // Best-effort: a parked parent subflow step is only woken by propagation.
+    // The parent's flow may be gone too (same deploy) — then its own messages
+    // meet this same policy, so swallow and log rather than block the ack.
+    try {
+      await this.dispatcher.propagateToParent(msg.runId, {
+        kind: "failed",
+        error: serialized,
+      });
+    } catch (propagateErr) {
+      this.deps.emitLog({
+        level: "warn",
+        msg: "worker.dispatch: snapshot-gone fail could not propagate to parent",
+        attrs: { ...attrs, error: String(propagateErr) },
+      });
+    }
+    await this.deps.queue.ack(msg.receipt);
   }
 
   private async drain(): Promise<void> {

--- a/packages/core/src/worker.ts
+++ b/packages/core/src/worker.ts
@@ -17,6 +17,8 @@ const DEFAULT_CONCURRENCY = 4;
 const DEFAULT_POLL_INTERVAL_MS: Millis = 1_000;
 const DEFAULT_TIMER_SWEEP_INTERVAL_MS: Millis = 30_000;
 const SNAPSHOT_GONE_FALLBACK_NACK_DELAY_MS: Millis = 30_000;
+const MAX_DEQUEUE_BACKOFF_MS: Millis = 30_000;
+const MIN_DEQUEUE_BACKOFF_MS: Millis = 50;
 
 // Bounds redelivery of a message whose run is pinned to a flow snapshot no
 // longer in any live registry. "retry" exists ONLY for the rolling-deploy
@@ -113,7 +115,13 @@ class WorkerImpl implements Worker {
     } catch {}
   }
 
+  // MUST settle only via the abort signal. A rejection escaping this loop
+  // silently ends ALL flow processing in a process that otherwise looks
+  // healthy — observed in prod as one transient `pgmq.read` connection
+  // timeout killing the loop, then 37h of fleet-wide stuck runs because
+  // nothing restarts it. Every await below is therefore guarded.
   async run(): Promise<void> {
+    let dequeueFailures = 0;
     while (!this.aborted()) {
       // Time-based, not idle-gated: a worker pinned at full concurrency still
       // reaches this each iteration (the slots-full branch loops every ~50ms),
@@ -125,7 +133,25 @@ class WorkerImpl implements Worker {
         continue;
       }
 
-      const messages = await this.dequeue(slots);
+      let messages: readonly QueueMessage[];
+      try {
+        messages = await this.dequeue(slots);
+      } catch (err) {
+        dequeueFailures++;
+        this.deps.emitLog({
+          level: "error",
+          msg: "worker.dequeue failed; backing off",
+          attrs: {
+            error: String(err),
+            consecutiveFailures: dequeueFailures,
+            backoffMs: this.dequeueBackoffMs(dequeueFailures),
+          },
+        });
+        await this.sleep(this.dequeueBackoffMs(dequeueFailures));
+        continue;
+      }
+      dequeueFailures = 0;
+
       if (messages.length === 0) {
         await this.sleep(this.pollIntervalMs);
         continue;
@@ -157,6 +183,12 @@ class WorkerImpl implements Worker {
     });
   }
 
+  // Unlike run(), a dequeue failure here PROPAGATES. These are bounded calls
+  // that hand a result back to an awaiting caller, so a rejection is observed,
+  // not silent — the outage shape run() guards against cannot happen. The
+  // alternatives are both worse: retrying would let runUntilEmpty() hang for
+  // the length of a database outage, and swallowing would report an
+  // unreachable queue as a drained one.
   private async pump(opts: {
     shouldContinue: (processed: number) => boolean;
     batchSize: (processed: number) => number;
@@ -192,6 +224,19 @@ class WorkerImpl implements Worker {
 
   private async dequeue(count: number): Promise<readonly QueueMessage[]> {
     return this.deps.queue.dequeue({ count: Math.max(1, count) });
+  }
+
+  // Exponential, capped, reset on the first success: a one-off blip costs one
+  // poll interval, a real outage settles to a 30s cadence instead of hammering
+  // a down database and flooding logs. Anchored on pollIntervalMs (default 1s,
+  // so the default curve is 1s -> 30s) and floored so a 0/near-0 poll interval
+  // cannot turn a persistent failure into a tight loop.
+  private dequeueBackoffMs(consecutiveFailures: number): Millis {
+    const base = Math.max(this.pollIntervalMs, MIN_DEQUEUE_BACKOFF_MS);
+    return Math.min(
+      base * 2 ** (consecutiveFailures - 1),
+      MAX_DEQUEUE_BACKOFF_MS,
+    );
   }
 
   private fire(msg: QueueMessage): void {

--- a/packages/pgmq/src/pgmq-queue.ts
+++ b/packages/pgmq/src/pgmq-queue.ts
@@ -4,6 +4,7 @@ import type {
   Queue,
   QueueDequeueOpts,
   QueueEnqueueOpts,
+  QueueInspectEntry,
   QueueMessage,
   RunId,
   StepId,
@@ -159,6 +160,26 @@ function buildQueue(executor: Kysely<unknown>, config: QueueConfig): Queue {
       await sql`SELECT pgmq.set_vt(${queueName}, ${msgId}::bigint, ${vt}::int)`.execute(
         executor,
       );
+    },
+
+    async inspect(runId: RunId): Promise<readonly QueueInspectEntry[]> {
+      // Direct table read (pgmq stores queue "x" as pgmq.q_x) — pgmq has no
+      // query-by-payload API. Read-only; safe alongside consuming workers.
+      const { rows } = await sql<{
+        read_ct: number;
+        vt: Date | string;
+        message: unknown;
+      }>`SELECT read_ct, vt, message FROM ${sql.raw(`pgmq.q_${queueName}`)}
+          WHERE message->>'runId' = ${runId}`.execute(executor);
+      return rows.map((row) => {
+        const m = projectMessage("0", row.message, row.read_ct);
+        return {
+          stepId: m.stepId,
+          attempt: m.attempt,
+          readCount: row.read_ct,
+          visibleAt: row.vt instanceof Date ? row.vt : new Date(row.vt),
+        };
+      });
     },
   };
 }

--- a/packages/pgmq/src/pgmq-queue.ts
+++ b/packages/pgmq/src/pgmq-queue.ts
@@ -31,6 +31,8 @@ interface MessageEnvelope {
   readonly runId: string;
   readonly stepId: string;
   readonly attempt: number;
+  // Absent on messages enqueued before the field existed; see QueueMessage.
+  readonly flowId?: string;
 }
 
 interface QueueConfig {
@@ -98,6 +100,7 @@ function buildQueue(executor: Kysely<unknown>, config: QueueConfig): Queue {
         runId,
         stepId,
         attempt: options?.attempt ?? 1,
+        ...(options?.flowId !== undefined ? { flowId: options.flowId } : {}),
       };
       const delaySeconds = Math.max(
         0,
@@ -184,6 +187,7 @@ function projectMessage(
     attempt: envelope.attempt as AttemptNumber,
     readCount,
     payload: null,
+    ...(envelope.flowId !== undefined ? { flowId: envelope.flowId } : {}),
   };
 }
 

--- a/packages/pgmq/src/pgmq-queue.ts
+++ b/packages/pgmq/src/pgmq-queue.ts
@@ -113,11 +113,14 @@ function buildQueue(executor: Kysely<unknown>, config: QueueConfig): Queue {
     }: QueueDequeueOpts): Promise<readonly QueueMessage[]> {
       const { rows } = await sql<{
         msg_id: string | number | bigint;
+        read_ct: number;
         message: unknown;
-      }>`SELECT msg_id, message FROM pgmq.read(${queueName}, ${vtSeconds}::int, ${count}::int)`.execute(
+      }>`SELECT msg_id, read_ct, message FROM pgmq.read(${queueName}, ${vtSeconds}::int, ${count}::int)`.execute(
         executor,
       );
-      return rows.map((row) => projectMessage(row.msg_id, row.message));
+      return rows.map((row) =>
+        projectMessage(row.msg_id, row.message, row.read_ct),
+      );
     },
 
     async ack(receipt: string): Promise<void> {
@@ -160,6 +163,7 @@ function buildQueue(executor: Kysely<unknown>, config: QueueConfig): Queue {
 function projectMessage(
   rawMsgId: string | number | bigint,
   raw: unknown,
+  readCount: number,
 ): QueueMessage {
   if (
     raw === null ||
@@ -178,6 +182,7 @@ function projectMessage(
     runId: envelope.runId as RunId,
     stepId: envelope.stepId as StepId,
     attempt: envelope.attempt as AttemptNumber,
+    readCount,
     payload: null,
   };
 }

--- a/packages/postgres/src/integration.test.ts
+++ b/packages/postgres/src/integration.test.ts
@@ -878,7 +878,10 @@ d("@nagi-js/postgres — end-to-end conformance", () => {
         id: "pg-cancel-gc",
         input: passthroughSchema<Record<string, never>>(),
         build: (b) => ({
-          wait: b.signal({ schema: passthroughSchema<{ ok: true }>() }),
+          wait: b.signal({
+            timeoutMs: "unbounded" as const,
+            schema: passthroughSchema<{ ok: true }>(),
+          }),
         }),
         output: (s) => s.wait,
       });
@@ -939,6 +942,7 @@ d("@nagi-js/postgres — end-to-end conformance", () => {
         input: passthroughSchema<Record<string, never>>(),
         build: (b) => ({
           transcript: b.signal({
+            timeoutMs: "unbounded" as const,
             names: ["audioReady", "recordingReady"],
             schema: passthroughSchema<
               { audioUrl: string } | { transcript: string }

--- a/packages/postgres/src/store.ts
+++ b/packages/postgres/src/store.ts
@@ -446,6 +446,7 @@ class PostgresStore<DB = unknown> implements Store {
         expires_at: Date;
         status: StepRunStatus | null;
         child_active: boolean;
+        flow_id: string | null;
       }>`
         SELECT l.run_id, l.step_id, l.attempt, l.expires_at, s.status,
           EXISTS (
@@ -453,12 +454,15 @@ class PostgresStore<DB = unknown> implements Store {
              WHERE c.parent_run_id = l.run_id
                AND c.parent_step_id = l.step_id
                AND c.status IN ('pending', 'running')
-          ) AS child_active
+          ) AS child_active,
+          r.flow_id
           FROM ${sql.raw(this.t("lease"))} l
           LEFT JOIN ${sql.raw(this.t("step_run"))} s
             ON s.run_id = l.run_id
            AND s.step_id = l.step_id
            AND s.attempt = l.attempt
+          LEFT JOIN ${sql.raw(this.t("workflow_run"))} r
+            ON r.run_id = l.run_id
          WHERE l.expires_at < ${now}
          FOR UPDATE OF l SKIP LOCKED
          LIMIT ${limit}
@@ -507,6 +511,7 @@ class PostgresStore<DB = unknown> implements Store {
         await txQueue.enqueue(runId, stepId, {
           attempt: decision.nextAttempt,
           delayMs: decision.backoffMs,
+          ...(row.flow_id !== null ? { flowId: row.flow_id } : {}),
         });
 
         reaped.push({


### PR DESCRIPTION
Branch-wide hardening of the worker against the failure modes that have actually taken production down. Each commit closes one of them; the last two were written in response to **LYMO-1BF** (a 37-hour fleet-wide stall on 2026-08-27).

## Commits

| Commit | What it closes |
|---|---|
| `16db9ff` | Snapshot-gone redelivery was unbounded — observed at `read_ct` 660k over 8 days. Now: policy backoff, then terminal fail with a triagable `workflow_run.error`. |
| `9e4af18` | `NagiNonRetryableError` — permanently-unprocessable input fails on the attempt instead of burning the retry budget. |
| `4b20b2e` | **Breaking.** `b.signal` requires `timeoutMs`; unbounded waits must be written, not omitted. Plus the lease-hold watchdog. |
| `0d22d1f` | `maxConcurrencyPerFlow` — one wedged flow can no longer occupy every worker slot. |
| `f27b5b9` | `wf.inspectQueue` + `docs/OPERATIONS.md` — triage without hand-run SQL. |
| `d751145` | **Dequeue failure no longer kills the poll loop.** Details below. |
| `6405aac` | Migrates two `b.signal` call sites `4b20b2e` missed; `pnpm -r typecheck` was failing on this branch. |

## The dequeue fix (`d751145`)

`await this.dequeue(slots)` was the only unguarded await in `WorkerImpl.run()`. Every other await in the loop — `dispatchSafely`, `maybeSweepTimers`, `defer`, `sleep` — was already caught, but those guards protect *per-message* work. Dequeue sits in the loop's control path, so its rejection isn't one lost message: it ends the loop.

In production a single transient `pg-pool` connection timeout inside `pgmq.read` rejected `run()`. All flow processing stopped. The process stayed healthy enough — HTTP, pollers, monitors all fine — that nothing noticed for 37 hours. Every flow was affected; 81 messages sat at `read_ct = 0` with no live leases. Any deploy would have "fixed" it silently, which is why this class of outage had never been seen before: it only persists when nothing restarts the process.

`run()` now catches, logs `worker.dequeue failed; backing off` with `consecutiveFailures`/`backoffMs`, sleeps, and continues. Backoff is `max(pollIntervalMs, 50ms) × 2^(n-1)`, capped at 30s, reset on the first success — the default poll interval is 1s so the production curve is exactly 1s → 30s, while a fast-polling test gets a proportionally fast one. The 50ms floor keeps a `0`/near-`0` poll interval from turning a dead database into a tight loop.

## Reviewer notes

**`pump()` deliberately still propagates.** The spec this came from said to guard every `await this.dequeue(…)`, including in `pump()`. I don't think that hole is the same: `run()`'s rejection is silent — nobody awaits it, which *is* the outage — whereas `runOnce`/`runUntilEmpty` hand a result to an awaiting caller, so a rejection there is observed. Both alternatives are worse: retrying would let `runUntilEmpty()` hang for the length of a database outage, and swallowing would report an unreachable queue as a drained one, silently acking a cron as done. Reasoning is in the comment above `pump()`; the `Worker` interface now states both contracts.

**Three existing tests changed meaning.** `onLog.test.ts` and `runtime-run.test.ts` used a `CrashingQueue` to prove `nagi.run` logs `worker exited unexpectedly` — that is now precisely the behavior being removed. They're re-pointed at a `CrashingClock` (`clock.now()` in `maybeSweepTimers` is the one adapter call still outside a guard, so the crash path stays covered), and two new tests assert a crashing queue produces backoff logs and *no* loop exit.

**Open question, not addressed here.** `nagi.run()` at `runtime.ts:814` has the same hole the consumer just patched on its side: it catches the loop rejection, logs it, and never restarts. Consumers using nagi's own bootstrap inherit the unsupervised version. Left alone because it's beyond this root cause and the restart policy (bare retry vs. backoff vs. give-up budget) is a product decision — worth settling separately.

## Verification

`@nagi-js/core` 956/956, `otel` 54/54, `pgmq` 53/53. `pnpm -r typecheck` clean across all four packages (it was failing before `6405aac`). Postgres integration tests need a live database and were not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)