### PR TITLE
test(core): Worker is the harness — delete __dispatchDeps backdoor

### DIFF
--- a/.changeset/worker-as-test-surface.md
+++ b/.changeset/worker-as-test-surface.md
@@ -1,0 +1,13 @@
+---
+"@nagi-js/core": patch
+---
+
+Remove the undocumented `__dispatchDeps` property `nagi()` planted on the `wf`
+object. It was never part of the public API (non-enumerable, untyped) and
+existed only so core's own test harness could bypass the `Worker` with a
+private dispatcher; the harness now drives `wf.worker(...)` directly, so the
+real dequeue/admission/snapshot-gone loop is what every harness test covers.
+
+`Worker.runUntilEmpty({ deadline })` now reads the injected `Clock` for its
+deadline instead of `Date.now()` — the bounded drain's only wall-clock read.
+No behaviour change for any shipped clock.

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -775,12 +775,6 @@ async function nagiImpl<const TFlows extends ReadonlyArray<Flow>>(
       });
     },
   };
-  Object.defineProperty(wf, "__dispatchDeps", {
-    value: dispatchDeps,
-    enumerable: false,
-    writable: false,
-    configurable: false,
-  });
   // Trust boundary: persisted flow_id values were registered flow ids at write
   // time, so assert the erased string back to the registered union here.
   return wf as unknown as Wf<TFlows>;

--- a/packages/core/src/tests/dequeue-resilience.test.ts
+++ b/packages/core/src/tests/dequeue-resilience.test.ts
@@ -166,4 +166,20 @@ describe("worker.run dequeue resilience", () => {
       "Connection terminated",
     );
   });
+
+  it("runUntilEmpty rejects the same way", async () => {
+    const store = new InMemoryStore();
+    const queue = new FlakyDequeueQueue(new InMemoryQueue(), 1);
+    const wf = await nagi({
+      flows: [noop],
+      store,
+      queue,
+      clock: new InMemoryClock(),
+    });
+    await wf.start(noop, {});
+
+    await expect(wf.worker().runUntilEmpty()).rejects.toThrow(
+      "Connection terminated",
+    );
+  });
 });

--- a/packages/core/src/tests/flow-snapshot-gone.test.ts
+++ b/packages/core/src/tests/flow-snapshot-gone.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { flow } from "../builder";
-import { NagiFlowSnapshotGoneError, NagiSnapshotDriftError } from "../errors";
+import { NagiSnapshotDriftError } from "../errors";
 import { InMemoryClock, InMemoryQueue, InMemoryStore } from "../memory";
 import { nagi } from "../runtime";
-import type { Fact, RunId } from "../types";
+import type { Fact, LogEntry, RunId } from "../types";
 import { passthroughSchema } from "./test-helpers";
 
 function makeFlowA() {
@@ -28,7 +28,7 @@ function makeFlowB() {
 }
 
 describe("NagiFlowSnapshotGoneError", () => {
-  it("dispatch on a run whose flow_hash is not in the current registry throws NagiFlowSnapshotGoneError", async () => {
+  it("dispatching a run whose flow_hash is not in the current registry is snapshot-gone: nacked for a frozen-version worker, step never runs", async () => {
     const store = new InMemoryStore();
     const queue = new InMemoryQueue();
     const clock = new InMemoryClock();
@@ -39,18 +39,43 @@ describe("NagiFlowSnapshotGoneError", () => {
     const runId = await wfA.start(fA, {});
 
     // Process B: same store, but flow body differs → different flowHash. The
-    // queued message is for the old hash; flowFor must throw.
+    // queued message is for the old hash.
     const fB = makeFlowB();
-    const wfB = await nagi({ flows: [fB], store, queue, clock });
+    const logs: LogEntry[] = [];
+    const wfB = await nagi({
+      flows: [fB],
+      store,
+      queue,
+      clock,
+      onLog: (e) => logs.push(e),
+    });
 
-    const deps = (
-      wfB as unknown as {
-        __dispatchDeps: { flowFor: (r: RunId) => Promise<unknown> };
-      }
-    ).__dispatchDeps;
-    await expect(deps.flowFor(runId)).rejects.toBeInstanceOf(
-      NagiFlowSnapshotGoneError,
+    const seenReadCounts: number[] = [];
+    const { processed } = await wfB
+      .worker({
+        timerSweepIntervalMs: 0,
+        snapshotGonePolicy: (readCount) => {
+          seenReadCounts.push(readCount);
+          return { action: "retry", delayMs: 60_000 };
+        },
+      })
+      .runUntilEmpty();
+    expect(processed).toBe(1);
+    expect(seenReadCounts).toEqual([1]);
+
+    const warn = logs.find((l) =>
+      l.msg.includes("flow snapshot gone — nacking"),
     );
+    expect(warn?.level).toBe("warn");
+    expect(warn?.attrs).toMatchObject({ runId, flowId: "fA", readCount: 1 });
+
+    // Message kept for a frozen-version worker (delayed), run untouched.
+    const [entry] = await wfB.inspectQueue(runId);
+    expect(entry).toMatchObject({ stepId: "s", readCount: 1 });
+    expect(entry?.visibleAt.getTime()).toBeGreaterThan(Date.now());
+    const state = await store.loadRunState(runId);
+    expect(state.phase.tag).toBe("running");
+    expect(state.facts.some((f) => f.kind === "step.started")).toBe(false);
   });
 
   it("includes pinnedHash and currentHash for diagnostic", async () => {
@@ -63,25 +88,39 @@ describe("NagiFlowSnapshotGoneError", () => {
     const runId = await wfA.start(fA, {});
 
     const fB = makeFlowB();
-    const wfB = await nagi({ flows: [fB], store, queue, clock });
-    const deps = (
-      wfB as unknown as {
-        __dispatchDeps: { flowFor: (r: RunId) => Promise<unknown> };
-      }
-    ).__dispatchDeps;
-    try {
-      await deps.flowFor(runId);
-      throw new Error("expected NagiFlowSnapshotGoneError");
-    } catch (err) {
-      expect(err).toBeInstanceOf(NagiFlowSnapshotGoneError);
-      const e = err as NagiFlowSnapshotGoneError;
-      expect(e.runId).toBe(runId);
-      expect(e.flowId).toBe("fA");
-      expect(typeof e.pinnedHash).toBe("string");
-      expect(e.pinnedHash.length).toBeGreaterThan(0);
-      expect(typeof e.currentHash).toBe("string");
-      expect(e.currentHash).not.toBe(e.pinnedHash);
+    const logs: LogEntry[] = [];
+    const wfB = await nagi({
+      flows: [fB],
+      store,
+      queue,
+      clock,
+      onLog: (e) => logs.push(e),
+    });
+    await wfB
+      .worker({
+        timerSweepIntervalMs: 0,
+        snapshotGonePolicy: () => ({ action: "fail" }),
+      })
+      .runUntilEmpty();
+
+    const failed = logs.find((l) =>
+      l.msg.includes("redelivery budget exhausted"),
+    );
+    expect(failed?.level).toBe("error");
+    const attrs = failed?.attrs ?? {};
+    expect(attrs["runId"]).toBe(runId);
+    expect(attrs["flowId"]).toBe("fA");
+    expect(typeof attrs["pinnedHash"]).toBe("string");
+    expect(String(attrs["pinnedHash"]).length).toBeGreaterThan(0);
+    expect(typeof attrs["currentHash"]).toBe("string");
+    expect(attrs["currentHash"]).not.toBe(attrs["pinnedHash"]);
+
+    const state = await store.loadRunState(runId);
+    expect(state.phase.tag).toBe("failed");
+    if (state.phase.tag === "failed") {
+      expect(state.phase.error.name).toBe("NagiFlowSnapshotGoneError");
     }
+    expect(await wfB.inspectQueue(runId)).toHaveLength(0);
   });
 
   it("wf.cancel on a run with a gone flow_hash succeeds (cancel bypasses flow registry)", async () => {
@@ -160,13 +199,25 @@ describe("NagiFlowSnapshotGoneError", () => {
     const runId = await wfA.start(fA, {});
 
     // Re-create nagi with the SAME flow definition → same hash.
-    const wfA2 = await nagi({ flows: [fA], store, queue, clock });
-    const deps = (
-      wfA2 as unknown as {
-        __dispatchDeps: { flowFor: (r: RunId) => Promise<unknown> };
-      }
-    ).__dispatchDeps;
-    await expect(deps.flowFor(runId)).resolves.toBeDefined();
+    const logs: LogEntry[] = [];
+    const wfA2 = await nagi({
+      flows: [fA],
+      store,
+      queue,
+      clock,
+      onLog: (e) => logs.push(e),
+    });
+    const { processed } = await wfA2
+      .worker({
+        timerSweepIntervalMs: 0,
+        snapshotGonePolicy: () => {
+          throw new Error("policy must not run when the hash matches");
+        },
+      })
+      .runUntilEmpty();
+    expect(processed).toBe(1);
+    expect((await store.loadRunState(runId)).phase.tag).toBe("completed");
+    expect(logs.some((l) => l.msg.includes("snapshot gone"))).toBe(false);
   });
 
   it("is exported from @nagi-js/core", async () => {

--- a/packages/core/src/tests/heartbeat.test.ts
+++ b/packages/core/src/tests/heartbeat.test.ts
@@ -4,24 +4,14 @@ import { InMemoryClock, InMemoryQueue, InMemoryStore } from "../memory";
 import { nagi } from "../runtime";
 import { isTerminalRun } from "../state";
 import { startHeartbeat } from "../step-exec";
-import type { Queue, RunId, Store } from "../types";
-import { passthroughSchema } from "./test-helpers";
-
-function makeStore(extendLease = vi.fn().mockResolvedValue(undefined)): {
-  store: Store;
-  extendLease: ReturnType<typeof vi.fn>;
-} {
-  const store = { extendLease } as unknown as Store;
-  return { store, extendLease };
-}
+import type { RunId } from "../types";
+import { leasePorts, passthroughSchema } from "./test-helpers";
 
 describe("startHeartbeat", () => {
   it("extends the lease every interval until stopped", async () => {
     vi.useFakeTimers();
     try {
-      const extend = vi.fn().mockResolvedValue(undefined);
-      const queue = { extend } as unknown as Queue;
-      const { store, extendLease } = makeStore();
+      const { queue, store, extend, extendLease } = leasePorts();
       const emitLog = vi.fn();
 
       const hb = startHeartbeat({
@@ -54,10 +44,7 @@ describe("startHeartbeat", () => {
   it("warns on each holdWarnMs crossing while a step holds its slot (lease-hold watchdog)", async () => {
     vi.useFakeTimers();
     try {
-      const queue = {
-        extend: vi.fn().mockResolvedValue(undefined),
-      } as unknown as Queue;
-      const { store } = makeStore();
+      const { queue, store } = leasePorts();
       const emitLog = vi.fn();
 
       const hb = startHeartbeat({
@@ -104,12 +91,8 @@ describe("startHeartbeat", () => {
   it("keeps beating and logs a warning when an extension fails", async () => {
     vi.useFakeTimers();
     try {
-      const extend = vi
-        .fn()
-        .mockRejectedValueOnce(new Error("boom"))
-        .mockResolvedValue(undefined);
-      const queue = { extend } as unknown as Queue;
-      const { store } = makeStore();
+      const { queue, store, extend } = leasePorts();
+      extend.mockRejectedValueOnce(new Error("boom"));
       const emitLog = vi.fn();
 
       const hb = startHeartbeat({
@@ -140,13 +123,8 @@ describe("startHeartbeat", () => {
   it("logs a warning but keeps beating when store.extendLease fails", async () => {
     vi.useFakeTimers();
     try {
-      const extend = vi.fn().mockResolvedValue(undefined);
-      const queue = { extend } as unknown as Queue;
-      const extendLease = vi
-        .fn()
-        .mockRejectedValueOnce(new Error("store boom"))
-        .mockResolvedValue(undefined);
-      const { store } = makeStore(extendLease);
+      const { queue, store, extendLease } = leasePorts();
+      extendLease.mockRejectedValueOnce(new Error("store boom"));
       const emitLog = vi.fn();
 
       const hb = startHeartbeat({

--- a/packages/core/src/tests/lease-reaper.test.ts
+++ b/packages/core/src/tests/lease-reaper.test.ts
@@ -6,8 +6,8 @@ import {
 } from "../lease-reaper";
 import { InMemoryClock, InMemoryQueue, InMemoryStore } from "../memory";
 import { nagi } from "../runtime";
-import type { AttemptNumber, Fact, Queue, RunId, StepId } from "../types";
-import { passthroughSchema } from "./test-helpers";
+import type { AttemptNumber, Fact, RunId, StepId } from "../types";
+import { leasePorts, passthroughSchema } from "./test-helpers";
 
 const RUN_ID = "run-test" as RunId;
 const STEP_ID = "s1" as StepId;
@@ -239,10 +239,7 @@ describe("Heartbeat extends both queue VT and store lease", () => {
   it("extends queue VT and store lease atomically per tick", async () => {
     vi.useFakeTimers();
     try {
-      const extend = vi.fn().mockResolvedValue(undefined);
-      const extendLease = vi.fn().mockResolvedValue(undefined);
-      const queue = { extend } as unknown as Queue;
-      const store = { extendLease } as unknown as import("../types").Store;
+      const { queue, store, extend, extendLease } = leasePorts();
       const emitLog = vi.fn();
       const { startHeartbeat } = await import("../step-exec");
       const hb = startHeartbeat({

--- a/packages/core/src/tests/nagi-abort-error.test.ts
+++ b/packages/core/src/tests/nagi-abort-error.test.ts
@@ -59,7 +59,6 @@ describe("NagiAbortError shape (N12, D10=A)", () => {
       }),
     });
     const h = await makeHarness(f);
-    (h.deps as { cancelPollIntervalMs?: number }).cancelPollIntervalMs = 20;
     const runId = await h.wf.start(f, {});
     const worker = h.startWorker({ pollIntervalMs: 5 });
     try {

--- a/packages/core/src/tests/operator.test.ts
+++ b/packages/core/src/tests/operator.test.ts
@@ -211,7 +211,6 @@ describe("wf.operator().retry()", () => {
       }),
     });
     const h = await makeHarness(f);
-    (h.deps as { cancelPollIntervalMs?: number }).cancelPollIntervalMs = 20;
     const runId = await h.wf.start(f, {});
     const worker = h.startWorker({ pollIntervalMs: 5 });
     try {

--- a/packages/core/src/tests/per-flow-concurrency.test.ts
+++ b/packages/core/src/tests/per-flow-concurrency.test.ts
@@ -2,8 +2,20 @@ import { describe, expect, it } from "vitest";
 import { flow } from "../builder";
 import { InMemoryClock, InMemoryQueue, InMemoryStore } from "../memory";
 import { nagi } from "../runtime";
-import type { RunId } from "../types";
+import type { QueueEnqueueOpts, RunId, StepId } from "../types";
 import { passthroughSchema } from "./test-helpers";
+
+// A pre-upgrade queue adapter: its envelope has no flowId.
+class LegacyQueue extends InMemoryQueue {
+  override async enqueue(
+    runId: RunId,
+    stepId: StepId,
+    opts?: QueueEnqueueOpts,
+  ): Promise<void> {
+    const { flowId: _flowId, ...legacy } = opts ?? {};
+    return super.enqueue(runId, stepId, legacy);
+  }
+}
 
 // The outage shape this bounds: N steps of ONE flow wedge in their handlers
 // and hold every worker slot, so no other flow's runs ever get scheduled.
@@ -90,7 +102,7 @@ describe("worker maxConcurrencyPerFlow", () => {
 
   it("messages without flowId are exempt (pre-upgrade messages still dispatch)", async () => {
     const store = new InMemoryStore();
-    const queue = new InMemoryQueue();
+    const queue = new LegacyQueue();
     const clock = new InMemoryClock();
 
     const f = flow({
@@ -101,17 +113,20 @@ describe("worker maxConcurrencyPerFlow", () => {
       }),
     });
     const wf = await nagi({ flows: [f], store, queue, clock });
-    const runId = await wf.start(f, {});
+    const runIds = [await wf.start(f, {}), await wf.start(f, {})];
 
-    // Strip flowId from the queued message, simulating a pre-upgrade envelope.
-    const pending = (
-      queue as unknown as { pending: Array<Record<string, unknown>> }
-    ).pending;
-    for (const item of pending) delete item["flowId"];
-
-    await wf
-      .worker({ maxConcurrencyPerFlow: 1, timerSweepIntervalMs: 0 })
-      .runUntilEmpty();
-    expect((await store.loadRunState(runId)).phase.tag).toBe("completed");
+    // Cap of 1 with two same-flow messages in one batch: a flowId-bearing
+    // second message would be deferred; exempt messages both dispatch.
+    const { processed } = await wf
+      .worker({
+        concurrency: 2,
+        maxConcurrencyPerFlow: 1,
+        timerSweepIntervalMs: 0,
+      })
+      .runOnce({ maxSteps: 2 });
+    expect(processed).toBe(2);
+    for (const runId of runIds) {
+      expect((await store.loadRunState(runId)).phase.tag).toBe("completed");
+    }
   });
 });

--- a/packages/core/src/tests/queue-bootstrap.test.ts
+++ b/packages/core/src/tests/queue-bootstrap.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import { flow } from "../builder";
-import { type DispatchDeps, makeDispatcher } from "../dispatch";
 import { InMemoryQueue, InMemoryStore } from "../memory";
 import { nagi } from "../runtime";
 import { passthroughSchema, runFlow } from "./test-helpers";
@@ -33,20 +32,14 @@ describe("nagi() — auto queue-schema bootstrap", () => {
     expect(queue.ensureSchemaCalls).toBe(1);
   });
 
-  it("does not call ensureSchema again on wf.start, wf.worker, or dispatch", async () => {
+  it("does not call ensureSchema again on wf.start, wf.worker, or the worker drain", async () => {
     const queue = new SpyQueue();
     const store = new InMemoryStore();
     const wf = await nagi({ flows: [echo], store, queue });
     expect(queue.ensureSchemaCalls).toBe(1);
 
-    const deps = (wf as unknown as { __dispatchDeps: DispatchDeps })
-      .__dispatchDeps;
-    const dispatcher = makeDispatcher(deps);
     const runId = await wf.start(echo, { x: 1 });
-    wf.worker({ pollIntervalMs: 5 });
-    for (const msg of await queue.dequeue({ count: 32 })) {
-      await dispatcher.dispatchMessage(msg);
-    }
+    await wf.worker({ timerSweepIntervalMs: 0 }).runUntilEmpty();
     expect((await store.loadRunState(runId)).phase.tag).toBe("completed");
     expect(queue.ensureSchemaCalls).toBe(1);
   });

--- a/packages/core/src/tests/signal-timeout.test.ts
+++ b/packages/core/src/tests/signal-timeout.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { flow } from "../builder";
-import { makeDispatcher } from "../dispatch";
-import { emptySchema, makeHarness, passthroughSchema } from "./test-helpers";
+import {
+  emptySchema,
+  type Harness,
+  makeHarness,
+  passthroughSchema,
+} from "./test-helpers";
 
 // A signal gate with a downstream task that needs it — the awaitAudio shape from
 // lymo's videoAnalysis. timeoutMs omitted ⇒ the signal parks forever (today's
@@ -28,13 +32,25 @@ function gatedFlow(opts: { id: string; timeoutMs?: number }) {
   });
 }
 
-const FAR_FUTURE = () => new Date(Date.now() + 3_600_000);
+// Runs the real worker loop, sweeping every 1ms, for the duration of `body`.
+async function whileSweeping<T>(
+  h: Harness,
+  body: () => Promise<T>,
+): Promise<T> {
+  const worker = h.startWorker({ pollIntervalMs: 1, timerSweepIntervalMs: 1 });
+  try {
+    return await body();
+  } finally {
+    await worker.stop();
+  }
+}
+
+const tick = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
 describe("b.signal timeout", () => {
   it("fails the awaiting signal step (and cascades) once its deadline passes", async () => {
-    const f = gatedFlow({ id: "to-fires", timeoutMs: 1_000 });
+    const f = gatedFlow({ id: "to-fires", timeoutMs: 5 });
     const h = await makeHarness(f);
-    const dispatcher = makeDispatcher(h.deps);
 
     const runId = await h.wf.start(f, {});
     await h.drain();
@@ -42,10 +58,7 @@ describe("b.signal timeout", () => {
       "awaitingSignal",
     );
 
-    const failed = await dispatcher.sweepTimers(FAR_FUTURE());
-    expect(failed).toBe(1);
-
-    const result = await h.result(runId);
+    const result = await whileSweeping(h, () => h.waitForEnd(runId));
     expect(result.status).toBe("failed");
     expect(result.stepStatus("awaitAudio")).toBe("failed");
     expect(result.error("awaitAudio").name).toBe("NagiSignalTimeoutError");
@@ -55,43 +68,35 @@ describe("b.signal timeout", () => {
   });
 
   it("does NOT fire before the deadline (fire_at gating)", async () => {
-    const f = gatedFlow({ id: "to-not-due", timeoutMs: 1_000 });
+    const f = gatedFlow({ id: "to-not-due", timeoutMs: 60_000 });
     const h = await makeHarness(f);
-    const dispatcher = makeDispatcher(h.deps);
 
     const runId = await h.wf.start(f, {});
     await h.drain();
 
-    // Sweep at ~now: the deadline (parked-at + 1s) hasn't passed.
-    const early = await dispatcher.sweepTimers(new Date());
-    expect(early).toBe(0);
-    expect((await h.store.loadRunState(runId)).steps["awaitAudio"]?.tag).toBe(
-      "awaitingSignal",
-    );
-
-    // …and it still fires once the deadline is past.
-    expect(await dispatcher.sweepTimers(FAR_FUTURE())).toBe(1);
-    expect((await h.result(runId)).status).toBe("failed");
+    // Many sweeps, none due: the deadline (parked-at + 60s) hasn't passed.
+    await whileSweeping(h, () => tick(30));
+    const result = await h.result(runId);
+    expect(result.stepStatus("awaitAudio")).toBe("running");
+    expect(result.factCount("step.failed")).toBe(0);
   });
 
   it("never arms a timer for a signal without timeoutMs (parks forever, as before)", async () => {
     const f = gatedFlow({ id: "to-none" });
     const h = await makeHarness(f);
-    const dispatcher = makeDispatcher(h.deps);
 
     const runId = await h.wf.start(f, {});
     await h.drain();
 
-    expect(await dispatcher.sweepTimers(FAR_FUTURE())).toBe(0);
-    expect((await h.store.loadRunState(runId)).steps["awaitAudio"]?.tag).toBe(
-      "awaitingSignal",
-    );
+    await whileSweeping(h, () => tick(30));
+    const result = await h.result(runId);
+    expect(result.stepStatus("awaitAudio")).toBe("running");
+    expect(result.factCount("step.failed")).toBe(0);
   });
 
   it("is a no-op once the signal was delivered (delivery wins; timer disarmed)", async () => {
-    const f = gatedFlow({ id: "to-delivered", timeoutMs: 1_000 });
+    const f = gatedFlow({ id: "to-delivered", timeoutMs: 5 });
     const h = await makeHarness(f);
-    const dispatcher = makeDispatcher(h.deps);
 
     const runId = await h.wf.start(f, {});
     await h.drain();
@@ -99,21 +104,24 @@ describe("b.signal timeout", () => {
     await h.drain();
     expect((await h.result(runId)).status).toBe("completed");
 
-    // A late sweep finds no armed timer (disarmed on deliver) and no awaiting
-    // step — nothing to fail.
-    expect(await dispatcher.sweepTimers(FAR_FUTURE())).toBe(0);
-    expect((await h.result(runId)).status).toBe("completed");
+    // Sweeps well past the deadline find no armed timer (disarmed on deliver)
+    // and no awaiting step — nothing to fail.
+    await whileSweeping(h, () => tick(30));
+    const result = await h.result(runId);
+    expect(result.status).toBe("completed");
+    expect(result.factCount("step.failed")).toBe(0);
   });
 
-  it("is idempotent: a second sweep does not re-fail or duplicate facts", async () => {
-    const f = gatedFlow({ id: "to-idempotent", timeoutMs: 1_000 });
+  it("is idempotent: repeated sweeps do not re-fail or duplicate facts", async () => {
+    const f = gatedFlow({ id: "to-idempotent", timeoutMs: 5 });
     const h = await makeHarness(f);
-    const dispatcher = makeDispatcher(h.deps);
 
     const runId = await h.wf.start(f, {});
     await h.drain();
-    expect(await dispatcher.sweepTimers(FAR_FUTURE())).toBe(1);
-    expect(await dispatcher.sweepTimers(FAR_FUTURE())).toBe(0);
+    await whileSweeping(h, async () => {
+      await h.waitForEnd(runId);
+      await tick(30);
+    });
 
     const result = await h.result(runId);
     expect(result.status).toBe("failed");
@@ -122,7 +130,7 @@ describe("b.signal timeout", () => {
   });
 
   it("fires onStepError and onFlowError when a signal times out (parity with other failures)", async () => {
-    const f = gatedFlow({ id: "to-hooks", timeoutMs: 1_000 });
+    const f = gatedFlow({ id: "to-hooks", timeoutMs: 5 });
     const stepErrors: Array<{ stepId: string; name: string }> = [];
     let flowErrored = false;
     const h = await makeHarness(f, {
@@ -135,11 +143,13 @@ describe("b.signal timeout", () => {
         },
       },
     });
-    const dispatcher = makeDispatcher(h.deps);
 
     const runId = await h.wf.start(f, {});
     await h.drain();
-    await dispatcher.sweepTimers(FAR_FUTURE());
+    await whileSweeping(h, async () => {
+      await h.waitForEnd(runId);
+      await tick(30);
+    });
 
     expect(stepErrors).toEqual([
       { stepId: "awaitAudio", name: "NagiSignalTimeoutError" },
@@ -148,23 +158,22 @@ describe("b.signal timeout", () => {
   });
 
   it("keeps the earliest deadline: re-arming does not push the timeout out (reaper-safe)", async () => {
-    const f = gatedFlow({ id: "to-earliest", timeoutMs: 1_000 });
+    const f = gatedFlow({ id: "to-earliest", timeoutMs: 5 });
     const h = await makeHarness(f);
-    const dispatcher = makeDispatcher(h.deps);
 
     const runId = await h.wf.start(f, {});
     await h.drain();
 
     // A lease-reap re-dispatch would re-arm; simulate it trying to shove the
-    // deadline 10h out. upsertTimer keeps the earliest, so the original ~1s
-    // deadline still wins and a sweep 1h out fires it.
+    // deadline 10h out. upsertTimer keeps the earliest, so the original ~5ms
+    // deadline still wins and the sweep fires it.
     await h.store.upsertTimer(
       runId,
       "awaitAudio",
       new Date(Date.now() + 10 * 3_600_000),
     );
-    expect(await dispatcher.sweepTimers(FAR_FUTURE())).toBe(1);
-    expect((await h.result(runId)).status).toBe("failed");
+    const result = await whileSweeping(h, () => h.waitForEnd(runId));
+    expect(result.status).toBe("failed");
   });
 
   it("the worker self-sweeps on its configured cadence (no external loop)", async () => {

--- a/packages/core/src/tests/subflow.test.ts
+++ b/packages/core/src/tests/subflow.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { flow } from "../builder";
 import { outputOf, stepStateOf } from "../state";
-import type { FlowStartedFact } from "../types";
+import type { AttemptNumber, FlowStartedFact } from "../types";
 import { makeHarness, passthroughSchema } from "./test-helpers";
 
 describe("b.subflow — happy path", () => {
@@ -398,45 +398,36 @@ describe("b.subflow — idempotent spawn (self-supersede regression)", () => {
       }),
       output: (steps) => steps.work,
     });
-    // Minimal parent — only needed to own a runId / parent link. We drive the
-    // duplicate spawn directly via startChildRun to model redelivery of the
-    // same (parentRunId, stepId, attempt) without lease/queue plumbing.
     const parent = flow({
       id: "parent-host",
       input: passthroughSchema<Record<string, never>>(),
-      build: (b) => ({ noop: b.task({ run: async () => ({ ok: true }) }) }),
+      build: (b) => ({ sub: b.subflow(child, { input: () => ({ x: 5 }) }) }),
     });
 
     const h = await makeHarness([parent, child]);
     const parentRunId = await h.wf.start(parent, {});
+    // At-least-once: the spawn message is delivered a second time at a higher
+    // attempt (what a lease-reap enqueues) — the SAME generation, so it must
+    // re-attach, not spawn a second child that self-supersedes. Queued ahead
+    // of the child's own work so the re-dispatch meets an in-flight child.
+    await h.queue.enqueue(parentRunId, "sub", {
+      attempt: 2 as AttemptNumber,
+      flowId: parent.id,
+    });
     await h.drain();
-
-    const parentRef = { runId: parentRunId, stepId: "sub", attempt: 1 };
-    const first = await h.deps.startChildRun({
-      child,
-      childInput: { x: 5 },
-      parent: parentRef,
-      generation: 0,
-    });
-    // A re-dispatch at a higher attempt (lease-reap) is the SAME generation, so
-    // it must re-attach — not spawn a second child that self-supersedes.
-    const second = await h.deps.startChildRun({
-      child,
-      childInput: { x: 5 },
-      parent: { ...parentRef, attempt: 2 },
-      generation: 0,
-    });
-
-    // Deterministic id ⇒ the redelivery re-attached to the same child.
-    expect(second).toBe(first);
 
     // Exactly one child run exists for this parent.
     const children = await h.store.listChildren(parentRunId);
-    expect(children).toEqual([first]);
+    expect(children).toHaveLength(1);
+    const [childRunId] = children;
+    if (childRunId === undefined) throw new Error("unreachable");
 
-    // The child was never canceled by a self-supersede; it runs to completion.
-    await h.drain();
-    const childState = await h.store.loadRunState(first);
-    expect(childState.phase.tag).toBe("completed");
+    // The child was never canceled by a self-supersede; both runs complete.
+    expect((await h.store.loadRunState(childRunId)).phase.tag).toBe(
+      "completed",
+    );
+    const result = await h.result(parentRunId);
+    expect(result.status).toBe("completed");
+    expect(result.output("sub")).toMatchObject({ output: { doubled: 10 } });
   });
 });

--- a/packages/core/src/tests/test-helpers.ts
+++ b/packages/core/src/tests/test-helpers.ts
@@ -1,4 +1,4 @@
-import { type DispatchDeps, makeDispatcher } from "../dispatch";
+import { type MockInstance, vi } from "vitest";
 import { InMemoryClock, InMemoryQueue, InMemoryStore } from "../memory";
 import { type NagiConfig, nagi, type Wf } from "../runtime";
 import { errorOf, isTerminalRun, runStatusOf, stepStatusOf } from "../state";
@@ -16,6 +16,7 @@ import type {
   SerializedError,
   StandardSchemaV1,
   StepStatus,
+  Worker,
   WorkerConfig,
 } from "../types";
 
@@ -111,12 +112,12 @@ export interface Harness {
   readonly queue: InMemoryQueue;
   readonly clock: InMemoryClock;
 
-  readonly deps: DispatchDeps;
-
   startWorker(config?: WorkerConfig): { stop: () => Promise<void> };
 
-  drainOnce(count?: number): Promise<number>;
-  drain(opts?: { maxIter?: number }): Promise<number>;
+  // Bounded drains through the real Worker at concurrency 1, so dispatch order
+  // is queue order. Both stop at the first empty dequeue.
+  drainOnce(maxSteps?: number): Promise<number>;
+  drain(opts?: { maxSteps?: number }): Promise<number>;
 
   waitForEnd(runId: RunId, timeoutMs?: number): Promise<Result>;
   waitForStep(
@@ -152,36 +153,23 @@ export async function makeHarness(
 
   if (flowList.length === 0) throw new Error("makeHarness: no flows provided");
 
-  const deps = (wf as unknown as { __dispatchDeps: DispatchDeps })
-    .__dispatchDeps;
-  const dispatcher = makeDispatcher(deps);
-
-  async function drainOnce(count = 32): Promise<number> {
-    const messages = await queue.dequeue({ count });
-    for (const msg of messages) {
-      await dispatcher.dispatchMessage(msg);
-    }
-    return messages.length;
-  }
+  const worker: Worker = wf.worker({ concurrency: 1 });
 
   return {
     wf,
     store,
     queue,
     clock,
-    deps,
 
     startWorker(config) {
       const ac = new AbortController();
-      const merged: WorkerConfig = {
-        pollIntervalMs: config?.pollIntervalMs ?? 5,
-        ...(config?.concurrency !== undefined
-          ? { concurrency: config.concurrency }
-          : {}),
-        signal: config?.signal ?? ac.signal,
-      };
-      const worker = wf.worker(merged);
-      const done = worker.run();
+      const done = wf
+        .worker({
+          pollIntervalMs: 5,
+          ...config,
+          signal: config?.signal ?? ac.signal,
+        })
+        .run();
       return {
         stop: async () => {
           ac.abort();
@@ -190,17 +178,18 @@ export async function makeHarness(
       };
     },
 
-    drainOnce,
+    async drainOnce(maxSteps = 1) {
+      const { processed } = await worker.runOnce({ maxSteps });
+      return processed;
+    },
 
     async drain(opts) {
-      const max = opts?.maxIter ?? 256;
-      let total = 0;
-      for (let i = 0; i < max; i++) {
-        const n = await drainOnce();
-        if (n === 0) return total;
-        total += n;
+      const maxSteps = opts?.maxSteps ?? 4096;
+      const { processed } = await worker.runOnce({ maxSteps });
+      if (processed >= maxSteps) {
+        throw new Error(`drain: exceeded ${maxSteps} steps`);
       }
-      throw new Error(`drain: exceeded ${max} iterations`);
+      return processed;
     },
 
     async waitForEnd(runId, timeoutMs = 3_000) {
@@ -231,6 +220,22 @@ export async function makeHarness(
     async result(runId) {
       return makeResult(await store.loadRunState(runId));
     },
+  };
+}
+
+export function leasePorts(): {
+  store: InMemoryStore;
+  queue: InMemoryQueue;
+  extendLease: MockInstance<InMemoryStore["extendLease"]>;
+  extend: MockInstance<InMemoryQueue["extend"]>;
+} {
+  const store = new InMemoryStore();
+  const queue = new InMemoryQueue();
+  return {
+    store,
+    queue,
+    extendLease: vi.spyOn(store, "extendLease").mockResolvedValue(undefined),
+    extend: vi.spyOn(queue, "extend").mockResolvedValue(undefined),
   };
 }
 

--- a/packages/core/src/worker.ts
+++ b/packages/core/src/worker.ts
@@ -178,7 +178,8 @@ class WorkerImpl implements Worker {
   ): Promise<WorkerRunResult> {
     const deadline = opts?.deadline;
     return this.pump({
-      shouldContinue: () => deadline === undefined || Date.now() < deadline,
+      shouldContinue: () =>
+        deadline === undefined || this.deps.clock.now().getTime() < deadline,
       batchSize: () => this.concurrency,
     });
   }

--- a/packages/postgres/src/integration.test.ts
+++ b/packages/postgres/src/integration.test.ts
@@ -1,4 +1,5 @@
 import {
+  type AttemptNumber,
   flow,
   InMemoryClock,
   InMemoryQueue,
@@ -755,7 +756,7 @@ d("@nagi-js/postgres — end-to-end conformance", () => {
       expect(children.length).toBe(1);
     }, 20_000);
 
-    it("re-spawning a subflow step re-attaches via PG (idempotent, no self-supersede)", async () => {
+    it("re-delivering a subflow step re-attaches via PG (idempotent, no self-supersede)", async () => {
       // Child has cancel-in-progress on a fixed key: if a re-delivery minted a
       // second child with a different id, the real SQL tryStartRun would cancel
       // the first. Deterministic ids make the existence check fire first, so the
@@ -774,53 +775,38 @@ d("@nagi-js/postgres — end-to-end conformance", () => {
       const parent = flow({
         id: "pg-idem-parent",
         input: passthroughSchema<Record<string, never>>(),
-        build: (b) => ({ noop: b.task({ run: async () => ({ ok: true }) }) }),
+        build: (b) => ({
+          sub: b.subflow(child, { input: () => ({ x: 5 }) }),
+        }),
       });
 
-      const wf = await makeNagi(parent, child);
+      const queue = new InMemoryQueue();
+      const wf = await nagi({
+        store: postgresStore({ db, schema }),
+        queue,
+        clock: new InMemoryClock(),
+        flows: [parent, child],
+      });
       const parentRunId = await wf.start(parent, {});
-      await runToEnd(wf, parentRunId);
-
-      const startChildRun = (
-        wf as unknown as {
-          __dispatchDeps: {
-            startChildRun: (a: {
-              readonly child: typeof child;
-              readonly childInput: unknown;
-              readonly parent: {
-                runId: RunId;
-                stepId: string;
-                attempt: number;
-              };
-              readonly generation: number;
-            }) => Promise<RunId>;
-          };
-        }
-      ).__dispatchDeps.startChildRun;
-
-      const parentRef = { runId: parentRunId, stepId: "sub", attempt: 1 };
-      const first = await startChildRun({
-        child,
-        childInput: { x: 5 },
-        parent: parentRef,
-        generation: 0,
+      // At-least-once: the spawn message arrives a second time at a higher
+      // attempt (what a lease-reap enqueues) but the SAME generation, so it
+      // must re-attach. Queued ahead of the child's own work so the
+      // re-dispatch meets an in-flight child; concurrency 1 keeps that order.
+      await queue.enqueue(parentRunId, "sub", {
+        attempt: 2 as AttemptNumber,
+        flowId: parent.id,
       });
-      // A lease-reap re-dispatch is a higher attempt but the SAME generation, so
-      // it must re-attach — not mint a second child that self-supersedes.
-      const second = await startChildRun({
-        child,
-        childInput: { x: 5 },
-        parent: { ...parentRef, attempt: 2 },
-        generation: 0,
-      });
-      expect(second).toBe(first);
+      await wf
+        .worker({ concurrency: 1, timerSweepIntervalMs: 0 })
+        .runUntilEmpty();
 
       const rows = await sql<{ run_id: string; status: string }>`
         SELECT run_id, status FROM ${sql.raw(`${schema}.workflow_run`)}
          WHERE parent_run_id = ${parentRunId}
       `.execute(db);
       expect(rows.rows.length).toBe(1);
-      expect(rows.rows[0]?.status).not.toBe("canceled");
+      expect(rows.rows[0]?.status).toBe("completed");
+      expect(await loadStatus(db, schema, parentRunId)).toBe("completed");
     }, 20_000);
 
     it("sweepLeases skips a subflow step while its child is active, reaps once terminal (child_active SQL)", async () => {


### PR DESCRIPTION
Closes #39.

## What changed

- `makeHarness` now drives `wf.worker({ concurrency: 1 })`: `drainOnce` / `drain` use `runOnce({ maxSteps })`, `startWorker` uses `run()` and forwards the full `WorkerConfig`. `Harness.deps` is removed.
- The non-enumerable `__dispatchDeps` backdoor is deleted from `runtime.ts`.
- `worker.ts`: the one real wall-clock read (`runUntilEmpty`'s deadline used `Date.now()`) now goes through the injected `Clock`. That is the whole `worker.ts` diff.
- Every test that reached past the interface is rewritten through it: `flow-snapshot-gone`, `queue-bootstrap`, `per-flow-concurrency` (a `LegacyQueue extends InMemoryQueue` replaces the `.pending` poke), `heartbeat` and `lease-reaper` (a `leasePorts()` spy helper over real `InMemoryStore` / `InMemoryQueue` replaces the `as unknown as Store` double casts), `signal-timeout`, `subflow`, `nagi-abort-error`, `operator`, and `packages/postgres/src/integration.test.ts`, which also used the backdoor.
- `dequeue-resilience.test.ts` gains a case: `runUntilEmpty` rejects on dequeue failure like `runOnce`.

## Why

Twenty harness-based test files bypassed the real Worker by building a private dispatcher from a hidden runtime property, so the Worker loop (dequeue backoff, flow admission, sweep cadence, snapshot-gone budget) was exercised by only a handful of tests. Investigation showed the issue's premise was off: the bounded drain was never non-deterministic. The harness simply never tried it.

## Reviewer notes

- `drainOnce()` semantics changed from "one dequeue batch of at most 32" to "at most `maxSteps` steps, default 1". The only test asserting the count expected 1 and passes unchanged.
- The signal-timeout tests now rely on real millisecond sleeps (5 ms timeouts, 30 ms windows) instead of a fake `now`, consistent with the existing `waitForEnd` style. The "does not fire before the deadline" case lost its "and still fires later" half because `upsertTimer` is first-write-wins; firing is covered by the first case.
- No new seams. A controllable `InMemoryClock.now()` was considered and rejected because queue visibility and sweep cadence read real time anyway.
- **Pre-existing gap worth its own issue**: the bounded drain (`runOnce` / `runUntilEmpty`) never sweeps signal timeouts; only `run()` does. A cron-style deployment using the bounded drain would never fire them.
- The rewritten `integration.test.ts` case is typechecked but was not executed against a live Postgres.

## Verification

- `pnpm typecheck`, `pnpm verify:types`: clean. `pnpm lint`: clean (the pre-existing warning was in a rewritten file and is gone).
- `pnpm -F @nagi-js/core test`: 82 files, 958 tests passed (was 956).
- `pnpm -F @nagi-js/postgres test`: 83 passed, 34 skipped.
- Grep proof: `__dispatchDeps`, `as unknown as Store|Queue`, `.deps`, and `makeDispatcher` no longer appear anywhere under `packages/*/src` tests.
- Independent review of this branch was started but interrupted by a session restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
