### PR TITLE
refactor(core): one retry/backoff module; DEFAULT_RETRY defined once

### DIFF
--- a/.changeset/retry-policy-module.md
+++ b/.changeset/retry-policy-module.md
@@ -1,0 +1,19 @@
+---
+"@nagi-js/core": patch
+---
+
+Internal: every retry/backoff decision now lives in one module (`retry.ts`).
+`DEFAULT_RETRY` was defined twice with the same values — once for execution
+(`step-exec.ts`) and once for flow hashing (`canonicalize.ts`) — so a change
+to one either silently re-hashed every flow (stranding in-flight runs as
+snapshot-gone) or silently never took effect at runtime. It is now defined
+once and imported by both; the canonical values are pinned by test and are
+byte-identical to before, so **no flow hash changes**.
+
+The four backoff curves (step retry, dequeue outage backoff, snapshot-gone
+redelivery budget, lease-reap re-dispatch) are named pure functions with one
+signature shape, covered by a single table-driven test. Policy resolution
+(`handler.retry` → `nagi({ defaultRetry })` → built-in) is `resolveRetry`.
+
+No public API change: `defaultSnapshotGonePolicy` is still exported from the
+package root with identical behavior.

--- a/packages/core/src/canonicalize.ts
+++ b/packages/core/src/canonicalize.ts
@@ -12,6 +12,7 @@ import {
   type SubflowDef,
   type TaskDef,
 } from "./internal";
+import { DEFAULT_RETRY } from "./retry";
 import type {
   BackoffStrategy,
   Flow,
@@ -61,13 +62,6 @@ export interface CanonicalDag {
   readonly inputSchema: CanonicalSchema;
   readonly steps: readonly CanonicalStep[];
 }
-
-const DEFAULT_RETRY: CanonicalRetryPolicy = {
-  maxAttempts: 3,
-  backoff: "exponential",
-  initialDelayMs: 1_000,
-  maxDelayMs: 60_000,
-};
 
 let warnedAboutSourceHash = false;
 function warnSourceHashOnce(): void {

--- a/packages/core/src/exec/message.ts
+++ b/packages/core/src/exec/message.ts
@@ -14,13 +14,13 @@ import {
   selectArm,
   type TaskDef,
 } from "../internal";
+import { resolveRetry } from "../retry";
 import { deriveChildRunId } from "../run-id";
 import { stepStateOf } from "../scheduler";
 import { isAbortRequested, isTerminalRun, resolvedOf } from "../state";
 import {
   CANCEL_POLL_INTERVAL_MS,
   classifyFailure,
-  DEFAULT_RETRY,
   makeActivityCtx,
   makeStepCtx,
   resolveExecutionFact,
@@ -578,7 +578,7 @@ export function makeMessage(
     const handler = handlerDef(def);
 
     const postState = await store.loadRunState(runId);
-    const policy = handler?.retry ?? deps.defaultRetry ?? DEFAULT_RETRY;
+    const policy = resolveRetry(handler?.retry, deps.defaultRetry);
     const outcome = classifyFailure({
       attempt,
       policy,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,6 +38,7 @@ export {
   InMemoryTrigger,
   projectRunState,
 } from "./memory";
+export { defaultSnapshotGonePolicy } from "./retry";
 export { RunId } from "./run-id";
 export type {
   RunDescription,
@@ -208,4 +209,3 @@ export type {
   WorkerRunResult,
   WorkerRunUntilEmptyOpts,
 } from "./types";
-export { defaultSnapshotGonePolicy } from "./worker";

--- a/packages/core/src/lease-reaper.ts
+++ b/packages/core/src/lease-reaper.ts
@@ -1,3 +1,4 @@
+import { reapBackoff } from "./retry";
 import type { StepRunStatus } from "./run-view";
 import type { AttemptNumber, Millis, RunId, StepId } from "./types";
 
@@ -22,8 +23,7 @@ export type ReaperDecision =
 // terminal/gone, fall through and reap — the re-entrant subflow handler then
 // settles the parent (terminal child) or re-spawns (missing child). A still-live
 // lease means an active worker is heartbeating; reaping it would double-dispatch
-// a running step. Reap re-enqueues at attempt+1 with no backoff (the step body
-// already paid wall-clock waiting for the worker to die).
+// a running step.
 export function decideExpiredLeaseAction(args: {
   readonly lease: {
     readonly runId: RunId;
@@ -50,11 +50,8 @@ export function decideExpiredLeaseAction(args: {
   if (lease.expiresAt > now) {
     return { tag: "skip", reason: "still-live" };
   }
-  return {
-    tag: "reap",
-    nextAttempt: (lease.attempt + 1) as AttemptNumber,
-    backoffMs: 0 as Millis,
-  };
+  const nextAttempt = (lease.attempt + 1) as AttemptNumber;
+  return { tag: "reap", nextAttempt, backoffMs: reapBackoff(nextAttempt) };
 }
 
 export interface ReapedLease {

--- a/packages/core/src/retry.ts
+++ b/packages/core/src/retry.ts
@@ -1,0 +1,85 @@
+import type { Millis, RetryPolicy, SnapshotGonePolicy } from "./types";
+
+// Also the canonical fill-in for a step's omitted initialDelayMs/maxDelayMs,
+// so these values are hashed into every flow that declares a retry policy.
+// Changing them re-hashes those flows and strands their in-flight runs as
+// snapshot-gone; canonicalize.test.ts pins them.
+export const DEFAULT_RETRY = {
+  maxAttempts: 3,
+  backoff: "exponential",
+  initialDelayMs: 1_000,
+  maxDelayMs: 60_000,
+} as const satisfies RetryPolicy;
+
+export function resolveRetry(
+  handlerPolicy: RetryPolicy | undefined,
+  runtimeDefault: RetryPolicy | undefined,
+): RetryPolicy {
+  return handlerPolicy ?? runtimeDefault ?? DEFAULT_RETRY;
+}
+
+// Every backoff curve has this shape: the 1-based ordinal of the attempt being
+// scheduled in, the delay before it out. Curves that need configuration are
+// built by a factory that closes over it.
+export type Backoff = (attempt: number) => Millis;
+
+export function stepBackoff(policy: RetryPolicy): Backoff {
+  const initial = policy.initialDelayMs ?? DEFAULT_RETRY.initialDelayMs;
+  const max = policy.maxDelayMs ?? DEFAULT_RETRY.maxDelayMs;
+  return (attempt) => {
+    switch (policy.backoff) {
+      case "exponential":
+        return Math.min(initial * 2 ** Math.max(0, attempt - 1), max);
+      case "linear":
+        return Math.min(initial * Math.max(1, attempt), max);
+      case "fixed":
+        return Math.min(initial, max);
+    }
+  };
+}
+
+const MAX_DEQUEUE_BACKOFF_MS: Millis = 30_000;
+const MIN_DEQUEUE_BACKOFF_MS: Millis = 50;
+
+// Exponential, capped: a one-off blip costs one poll interval, a real outage
+// settles to a 30s cadence instead of hammering a down database and flooding
+// logs. Anchored on pollIntervalMs (default 1s, so the default curve is
+// 1s -> 30s) and floored so a 0/near-0 poll interval cannot turn a persistent
+// failure into a tight loop.
+export function dequeueBackoff(pollIntervalMs: Millis): Backoff {
+  const base = Math.max(pollIntervalMs, MIN_DEQUEUE_BACKOFF_MS);
+  return (consecutiveFailures) =>
+    Math.min(base * 2 ** (consecutiveFailures - 1), MAX_DEQUEUE_BACKOFF_MS);
+}
+
+// Quadratic backoff capped at 5 min, budget 60 deliveries ≈ a 4.2h retry
+// window. Rationale: the window must comfortably exceed the longest plausible
+// old/new worker overlap (a rolling deploy is minutes, but a wedged draining
+// task has been observed hanging on for hours), and 4h matches the house
+// signal-timeout constant while staying under typical stuck-run alerting
+// thresholds (6h) — so a run that is GOING to fail fails before it pages as
+// stuck. Within the window: fast redelivery early (sub-minute, when a frozen
+// worker most likely still exists), quiet later (5 min cadence, ~60 log lines
+// total for a run that never recovers — vs 660k at set_vt(0)).
+const SNAPSHOT_GONE_DELIVERY_BUDGET = 60;
+const MAX_SNAPSHOT_GONE_BACKOFF_MS: Millis = 300_000;
+
+export const snapshotGoneBackoff: Backoff = (readCount) =>
+  Math.min(readCount * readCount * 1_000, MAX_SNAPSHOT_GONE_BACKOFF_MS);
+
+// Bounds redelivery of a message whose run is pinned to a flow snapshot no
+// longer in any live registry. "retry" exists ONLY for the rolling-deploy
+// window, where a not-yet-replaced worker may still hold the pinned code and
+// can finish the run. Once that window has clearly passed, retrying is pure
+// poison: the observed failure mode was set_vt(0) redelivery ~1/s for 8 days
+// (read_ct 660k) drowning staging logs. "fail" is the honest terminal state —
+// the run cannot advance on any current code — and unlike the old behavior it
+// leaves a workflow_run.error a human can triage, then admin-restart.
+export const defaultSnapshotGonePolicy: SnapshotGonePolicy = (readCount) =>
+  readCount > SNAPSHOT_GONE_DELIVERY_BUDGET
+    ? { action: "fail" }
+    : { action: "retry", delayMs: snapshotGoneBackoff(readCount) };
+
+// A reaped step re-dispatches immediately: its body already paid wall-clock
+// waiting for the dead worker's lease to expire.
+export const reapBackoff: Backoff = () => 0;

--- a/packages/core/src/step-exec.ts
+++ b/packages/core/src/step-exec.ts
@@ -2,6 +2,7 @@ import { NagiCanceledError, NagiNonRetryableError } from "./errors";
 import { Facts } from "./facts";
 import { makeIdempotencyKey, makeOnce } from "./idempotency";
 import type { EmitLog } from "./internal";
+import { stepBackoff } from "./retry";
 import { isAbortRequested, isTerminalRun, stepStateOf } from "./state";
 import type {
   ActivityCtx,
@@ -21,13 +22,6 @@ import type {
   Store,
   Tx,
 } from "./types";
-
-export const DEFAULT_RETRY: RetryPolicy = {
-  maxAttempts: 3,
-  backoff: "exponential",
-  initialDelayMs: 1_000,
-  maxDelayMs: 60_000,
-};
 
 export const CANCEL_POLL_INTERVAL_MS = 250;
 
@@ -281,7 +275,7 @@ export function classifyFailure(args: {
     return { tag: "failed" };
   }
   if (attempt < policy.maxAttempts && retryAllows(policy, err)) {
-    return { tag: "retry", delayMs: computeBackoff(policy, attempt) };
+    return { tag: "retry", delayMs: stepBackoff(policy)(attempt) };
   }
   return { tag: "failed" };
 }
@@ -301,19 +295,6 @@ function findInCauseChain<T extends Error>(
     cursor = (cursor as { cause?: unknown }).cause;
   }
   return undefined;
-}
-
-export function computeBackoff(policy: RetryPolicy, attempt: number): Millis {
-  const initial = policy.initialDelayMs ?? 1_000;
-  const max = policy.maxDelayMs ?? 60_000;
-  switch (policy.backoff) {
-    case "exponential":
-      return Math.min(initial * 2 ** Math.max(0, attempt - 1), max);
-    case "linear":
-      return Math.min(initial * Math.max(1, attempt), max);
-    case "fixed":
-      return Math.min(initial, max);
-  }
 }
 
 function retryAllows(policy: RetryPolicy, err: unknown): boolean {

--- a/packages/core/src/tests/canonicalize.test.ts
+++ b/packages/core/src/tests/canonicalize.test.ts
@@ -5,6 +5,7 @@ import {
   sha256Canonical,
   stableStringify,
 } from "../canonicalize";
+import { DEFAULT_RETRY } from "../retry";
 import { passthroughSchema } from "./test-helpers";
 
 async function hashOf(f: Parameters<typeof canonicalize>[0]): Promise<string> {
@@ -440,6 +441,33 @@ describe("canonicalize — shape", () => {
       initialDelayMs: 1_000,
       maxDelayMs: 60_000,
     });
+  });
+
+  // DEFAULT_RETRY's delays are the canonical fill-in above, so they are hashed
+  // into every flow that declares a retry policy. An edit to them re-hashes
+  // those flows and strands every in-flight run as snapshot-gone — this pin
+  // makes that a loud test failure instead of a silent production incident.
+  it("pins the canonical retry defaults as literals", async () => {
+    expect(DEFAULT_RETRY).toEqual({
+      maxAttempts: 3,
+      backoff: "exponential",
+      initialDelayMs: 1_000,
+      maxDelayMs: 60_000,
+    });
+    const f = flow({
+      id: "retry-defaults-pin",
+      input: passthroughSchema<Record<string, never>>(),
+      build: (b) => ({
+        only: b.task({
+          retry: { maxAttempts: 2, backoff: "fixed" },
+          run: async () => null,
+        }),
+      }),
+    });
+    const dag = await canonicalize(f);
+    expect(stableStringify(dag.steps[0]?.retry)).toBe(
+      '{"backoff":"fixed","initialDelayMs":1000,"maxAttempts":2,"maxDelayMs":60000}',
+    );
   });
 
   it("emits a stable hex string from sha256Canonical (64 chars)", async () => {

--- a/packages/core/src/tests/dispatch.test.ts
+++ b/packages/core/src/tests/dispatch.test.ts
@@ -1,51 +1,15 @@
 import { describe, expect, it } from "vitest";
 import { flow } from "../builder";
-import { computeBackoff } from "../step-exec";
 import type {
   FlowCompleteEvent,
   FlowErrorEvent,
   FlowStartEvent,
   LogEntry,
-  RetryPolicy,
   StepErrorEvent,
   StepRetryEvent,
   StepStartEvent,
 } from "../types";
 import { makeHarness, passthroughSchema, spyOnLog } from "./test-helpers";
-
-describe("computeBackoff", () => {
-  const exp: RetryPolicy = {
-    maxAttempts: 99,
-    backoff: "exponential",
-    initialDelayMs: 100,
-    maxDelayMs: 10_000,
-  };
-  const lin: RetryPolicy = {
-    maxAttempts: 99,
-    backoff: "linear",
-    initialDelayMs: 100,
-    maxDelayMs: 10_000,
-  };
-  const fix: RetryPolicy = {
-    maxAttempts: 99,
-    backoff: "fixed",
-    initialDelayMs: 250,
-  };
-
-  it.each([
-    ["exponential, attempt 1", exp, 1, 100],
-    ["exponential, attempt 2", exp, 2, 200],
-    ["exponential, attempt 4", exp, 4, 800],
-    ["exponential, attempt 8 (capped)", { ...exp, maxDelayMs: 500 }, 8, 500],
-    ["linear, attempt 1", lin, 1, 100],
-    ["linear, attempt 5", lin, 5, 500],
-    ["linear, attempt 200 (capped)", lin, 200, 10_000],
-    ["fixed, any attempt", fix, 99, 250],
-    ["fixed, capped by maxDelay", { ...fix, maxDelayMs: 100 }, 1, 100],
-  ] as const)("%s → %d ms", (_label, policy, attempt, expected) => {
-    expect(computeBackoff(policy, attempt)).toBe(expected);
-  });
-});
 
 describe("dispatchMessage — driver", () => {
   it("happy path: completes a single task and finalizes the flow", async () => {

--- a/packages/core/src/tests/flow-snapshot-gone.test.ts
+++ b/packages/core/src/tests/flow-snapshot-gone.test.ts
@@ -284,7 +284,7 @@ describe("snapshot-gone poison handling", () => {
   });
 
   it("defaultSnapshotGonePolicy: quadratic backoff capped at 5min, fails past 60 deliveries", async () => {
-    const { defaultSnapshotGonePolicy } = await import("../worker");
+    const { defaultSnapshotGonePolicy } = await import("../retry");
     expect(defaultSnapshotGonePolicy(1)).toEqual({
       action: "retry",
       delayMs: 1_000,

--- a/packages/core/src/tests/retry.test.ts
+++ b/packages/core/src/tests/retry.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import {
+  type Backoff,
+  DEFAULT_RETRY,
+  defaultSnapshotGonePolicy,
+  dequeueBackoff,
+  reapBackoff,
+  resolveRetry,
+  snapshotGoneBackoff,
+  stepBackoff,
+} from "../retry";
+import type { RetryPolicy } from "../types";
+
+const exp: RetryPolicy = {
+  maxAttempts: 99,
+  backoff: "exponential",
+  initialDelayMs: 100,
+  maxDelayMs: 10_000,
+};
+const lin: RetryPolicy = {
+  maxAttempts: 99,
+  backoff: "linear",
+  initialDelayMs: 100,
+  maxDelayMs: 10_000,
+};
+const fix: RetryPolicy = {
+  maxAttempts: 99,
+  backoff: "fixed",
+  initialDelayMs: 250,
+};
+
+describe("backoff curves", () => {
+  it.each<[string, Backoff, number, number]>([
+    ["step exponential, attempt 1", stepBackoff(exp), 1, 100],
+    ["step exponential, attempt 2", stepBackoff(exp), 2, 200],
+    ["step exponential, attempt 4", stepBackoff(exp), 4, 800],
+    [
+      "step exponential, attempt 8 (capped)",
+      stepBackoff({ ...exp, maxDelayMs: 500 }),
+      8,
+      500,
+    ],
+    ["step linear, attempt 1", stepBackoff(lin), 1, 100],
+    ["step linear, attempt 5", stepBackoff(lin), 5, 500],
+    ["step linear, attempt 200 (capped)", stepBackoff(lin), 200, 10_000],
+    ["step fixed, any attempt", stepBackoff(fix), 99, 250],
+    [
+      "step fixed, capped by maxDelay",
+      stepBackoff({ ...fix, maxDelayMs: 100 }),
+      1,
+      100,
+    ],
+    [
+      "step omitted delays fall back to DEFAULT_RETRY",
+      stepBackoff({ maxAttempts: 3, backoff: "exponential" }),
+      2,
+      2_000,
+    ],
+    ["dequeue default poll (1s), failure 1", dequeueBackoff(1_000), 1, 1_000],
+    ["dequeue default poll (1s), failure 3", dequeueBackoff(1_000), 3, 4_000],
+    [
+      "dequeue default poll (1s), failure 10 (capped 30s)",
+      dequeueBackoff(1_000),
+      10,
+      30_000,
+    ],
+    ["dequeue poll 5ms floors to 50ms, failure 1", dequeueBackoff(5), 1, 50],
+    ["dequeue poll 5ms floors to 50ms, failure 3", dequeueBackoff(5), 3, 200],
+    ["dequeue poll 0 cannot tight-loop", dequeueBackoff(0), 1, 50],
+    ["snapshot-gone delivery 1", snapshotGoneBackoff, 1, 1_000],
+    ["snapshot-gone delivery 10", snapshotGoneBackoff, 10, 100_000],
+    [
+      "snapshot-gone delivery 18 (capped 5min)",
+      snapshotGoneBackoff,
+      18,
+      300_000,
+    ],
+    ["snapshot-gone delivery 60", snapshotGoneBackoff, 60, 300_000],
+    ["reap re-dispatch, any attempt", reapBackoff, 7, 0],
+  ])("%s → %d ms", (_label, curve, attempt, expected) => {
+    expect(curve(attempt)).toBe(expected);
+  });
+});
+
+describe("defaultSnapshotGonePolicy", () => {
+  it("retries on the curve through 60 deliveries, then fails", () => {
+    expect(defaultSnapshotGonePolicy(1)).toEqual({
+      action: "retry",
+      delayMs: 1_000,
+    });
+    expect(defaultSnapshotGonePolicy(60)).toEqual({
+      action: "retry",
+      delayMs: 300_000,
+    });
+    expect(defaultSnapshotGonePolicy(61)).toEqual({ action: "fail" });
+  });
+
+  it("total window sits between the 4h signal-timeout constant and 6h stuck-run alerting", () => {
+    let totalMs = 0;
+    for (let readCount = 1; readCount <= 60; readCount++) {
+      totalMs += snapshotGoneBackoff(readCount);
+    }
+    expect(totalMs).toBeGreaterThan(4 * 3_600_000);
+    expect(totalMs).toBeLessThan(6 * 3_600_000);
+  });
+});
+
+describe("resolveRetry", () => {
+  const handler: RetryPolicy = { maxAttempts: 7, backoff: "fixed" };
+  const runtime: RetryPolicy = { maxAttempts: 5, backoff: "linear" };
+
+  it.each<
+    [string, RetryPolicy | undefined, RetryPolicy | undefined, RetryPolicy]
+  >([
+    ["handler wins over runtime", handler, runtime, handler],
+    ["runtime wins over built-in", undefined, runtime, runtime],
+    ["built-in when neither set", undefined, undefined, DEFAULT_RETRY],
+  ])("%s", (_label, h, r, expected) => {
+    expect(resolveRetry(h, r)).toBe(expected);
+  });
+});

--- a/packages/core/src/worker.ts
+++ b/packages/core/src/worker.ts
@@ -1,6 +1,11 @@
 import { type DispatchDeps, type Dispatcher, makeDispatcher } from "./dispatch";
 import { NagiFlowSnapshotGoneError, serializeError } from "./errors";
 import { Facts } from "./facts";
+import {
+  type Backoff,
+  defaultSnapshotGonePolicy,
+  dequeueBackoff,
+} from "./retry";
 import type {
   Clock,
   Millis,
@@ -17,33 +22,6 @@ const DEFAULT_CONCURRENCY = 4;
 const DEFAULT_POLL_INTERVAL_MS: Millis = 1_000;
 const DEFAULT_TIMER_SWEEP_INTERVAL_MS: Millis = 30_000;
 const SNAPSHOT_GONE_FALLBACK_NACK_DELAY_MS: Millis = 30_000;
-const MAX_DEQUEUE_BACKOFF_MS: Millis = 30_000;
-const MIN_DEQUEUE_BACKOFF_MS: Millis = 50;
-
-// Bounds redelivery of a message whose run is pinned to a flow snapshot no
-// longer in any live registry. "retry" exists ONLY for the rolling-deploy
-// window, where a not-yet-replaced worker may still hold the pinned code and
-// can finish the run. Once that window has clearly passed, retrying is pure
-// poison: the observed failure mode was set_vt(0) redelivery ~1/s for 8 days
-// (read_ct 660k) drowning staging logs. "fail" is the honest terminal state —
-// the run cannot advance on any current code — and unlike the old behavior it
-// leaves a workflow_run.error a human can triage, then admin-restart.
-// Quadratic backoff capped at 5 min, budget 60 deliveries ≈ a 4.2h retry
-// window. Rationale: the window must comfortably exceed the longest plausible
-// old/new worker overlap (a rolling deploy is minutes, but a wedged draining
-// task has been observed hanging on for hours), and 4h matches the house
-// signal-timeout constant while staying under typical stuck-run alerting
-// thresholds (6h) — so a run that is GOING to fail fails before it pages as
-// stuck. Within the window: fast redelivery early (sub-minute, when a frozen
-// worker most likely still exists), quiet later (5 min cadence, ~60 log lines
-// total for a run that never recovers — vs 660k at set_vt(0)).
-export const defaultSnapshotGonePolicy: SnapshotGonePolicy = (readCount) => {
-  if (readCount > 60) return { action: "fail" };
-  return {
-    action: "retry",
-    delayMs: Math.min(readCount * readCount * 1_000, 300_000),
-  };
-};
 
 export interface WorkerDeps extends DispatchDeps {
   readonly clock: Clock;
@@ -57,6 +35,7 @@ class WorkerImpl implements Worker {
   private inFlight = 0;
   private readonly concurrency: number;
   private readonly pollIntervalMs: Millis;
+  private readonly dequeueBackoffMs: Backoff;
   private readonly signal: AbortSignal | undefined;
   private readonly dispatcher: Dispatcher;
   private readonly timerSweepIntervalMs: Millis;
@@ -71,6 +50,7 @@ class WorkerImpl implements Worker {
   ) {
     this.concurrency = Math.max(1, config?.concurrency ?? DEFAULT_CONCURRENCY);
     this.pollIntervalMs = config?.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.dequeueBackoffMs = dequeueBackoff(this.pollIntervalMs);
     this.signal = config?.signal;
     this.dispatcher = makeDispatcher(deps);
     this.snapshotGonePolicy =
@@ -224,19 +204,6 @@ class WorkerImpl implements Worker {
 
   private async dequeue(count: number): Promise<readonly QueueMessage[]> {
     return this.deps.queue.dequeue({ count: Math.max(1, count) });
-  }
-
-  // Exponential, capped, reset on the first success: a one-off blip costs one
-  // poll interval, a real outage settles to a 30s cadence instead of hammering
-  // a down database and flooding logs. Anchored on pollIntervalMs (default 1s,
-  // so the default curve is 1s -> 30s) and floored so a 0/near-0 poll interval
-  // cannot turn a persistent failure into a tight loop.
-  private dequeueBackoffMs(consecutiveFailures: number): Millis {
-    const base = Math.max(this.pollIntervalMs, MIN_DEQUEUE_BACKOFF_MS);
-    return Math.min(
-      base * 2 ** (consecutiveFailures - 1),
-      MAX_DEQUEUE_BACKOFF_MS,
-    );
   }
 
   private fire(msg: QueueMessage): void {


### PR DESCRIPTION
Closes #40.

## What changed

- New `packages/core/src/retry.ts` owning the single `DEFAULT_RETRY`, `resolveRetry(handlerPolicy, runtimeDefault)`, and the four backoff curves as named pure functions with one signature shape: step retry (was `step-exec.ts`), dequeue backoff (was `worker.ts`), the snapshot-gone delivery budget (was `worker.ts`), and lease-reap re-dispatch (was `lease-reaper.ts`).
- `canonicalize.ts` imports the shared defaults; its private `DEFAULT_RETRY` copy is deleted.
- The three-level `??` fallback chain in `exec/message.ts` is replaced by `resolveRetry`.
- One table-driven test file covers every curve, plus a test that pins the canonical retry defaults as literal values.

## Why

`DEFAULT_RETRY` was defined twice with the same values, once for execution and once for flow hashing. A change to either would silently change every flow hash (making every in-flight run snapshot-gone) or silently not take effect at runtime. Four independent backoff curves had no shared helper.

## Reviewer notes

- Flow hashes are unchanged: the existing 481-line `canonicalize.test.ts` fixtures pass untouched, and the new literal-defaults test makes any future edit to the defaults fail loudly instead of re-hashing every flow.
- The snapshot-gone budget curve moved without changing its numbers or the `SnapshotGonePolicy` public type and call site (that disposition is #41's concern).
- `patch` changeset for `@nagi-js/core`.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm verify:types`: clean.
- `pnpm -F @nagi-js/core test`: 978 tests passed.
- Independent review of this branch was started but interrupted by a session restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
